### PR TITLE
[fix] typo on podium padding rules

### DIFF
--- a/src/components/Podium/Podium.js
+++ b/src/components/Podium/Podium.js
@@ -19,7 +19,7 @@ const Podium = forwardRef(function PodiumRef(
   const classSet = cx(
     styles.base,
     styles[`${paddingTop ? paddingTop : verticalPadding}PaddingTop`],
-    styles[`${paddingBottom ? paddingTop : verticalPadding}PaddingBottom`],
+    styles[`${paddingBottom ? paddingBottom : verticalPadding}PaddingBottom`],
     className,
   );
 


### PR DESCRIPTION
Found a small typo when generating the podium padding class names. 