### PR TITLE
[Feature][AES-1587] Product Fifty Fifty Slice | Copy Pair not Rendering if 'copy' field is not populated.

### DIFF
--- a/src/components/DefinitionList/DefinitionList.js
+++ b/src/components/DefinitionList/DefinitionList.js
@@ -26,7 +26,7 @@ const DefinitionList = forwardRef(function DefinitionListRef(
   return (
     <dl className={classSet} ref={ref}>
       {items
-        .filter(({ description, term }) => description && term)
+        .filter(({ description, term }) => description || term)
         .map(({ description, id, term }) => (
           <Fragment key={id}>
             <dt className={termClassSet}>{term}</dt>
@@ -43,9 +43,9 @@ DefinitionList.propTypes = {
   isVisible: PropTypes.bool,
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      description: PropTypes.node.isRequired,
+      description: PropTypes.node,
       id: PropTypes.string.isRequired,
-      term: PropTypes.node.isRequired,
+      term: PropTypes.node,
     }),
   ),
   theme: PropTypes.oneOf(['dark', 'light']),

--- a/src/components/DefinitionList/DefinitionList.module.css
+++ b/src/components/DefinitionList/DefinitionList.module.css
@@ -29,7 +29,7 @@
 .term {
   position: relative;
   padding-top: 18px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   font-family: var(--font-family-sans-serif-medium);
 
   @media (--viewport-md) {

--- a/src/components/DefinitionList/DefinitionList.stories.mdx
+++ b/src/components/DefinitionList/DefinitionList.stories.mdx
@@ -10,6 +10,7 @@ import DefinitionListFixture from './DefinitionList.fixture';
 <Preview>
   <Story name="Base component">
     <DefinitionList
+      hasBottomBorder={knobs.boolean('hasBottomBorder', false, 'Presentation')}
       isVisible={knobs.boolean('isActive', true, 'Presentation')}
       items={knobs.object(
         'items',


### PR DESCRIPTION
This PR addressed, and removes the filter logic for pairs or terms and descriptions in Definition List to allow non pairs.

> Product Fifty Fifty Slice | Copy Pair not Rendering if 'copy' field is not populated.

https://aesoponline.atlassian.net/browse/AES-1587