### PR TITLE
[Update] issue with Podium Medium Padding Bottom & page title alignment

### DIFF
--- a/src/components/Podium/Podium.module.css
+++ b/src/components/Podium/Podium.module.css
@@ -53,7 +53,7 @@
   padding-bottom: 80px;
 
   @media (--viewport-md-only) {
-    padding-top: 100px;
+    padding-bottom: 100px;
   }
 
   @media (--viewport-lg) {

--- a/src/components/SectionHeading/SectionHeading.module.css
+++ b/src/components/SectionHeading/SectionHeading.module.css
@@ -11,11 +11,11 @@
   }
   @media (--viewport-md) {
     width: 40%;
-    margin-top: -25px;
+    margin-top: 85px;
     margin-left: 30%;
   }
   @media (--viewport-lg) {
-    padding-top: 125px;
+    margin-top: 110px;
   }
 }
 


### PR DESCRIPTION
MediumPaddingBottom was using `padding-top` instead of `padding-top`