### PR TITLE
[Feature/AES-155- twocolumn-ctas]: CTAs ins Body Copy

### DIFF
--- a/src/components/BodyCopy/BodyCopy.spec.js
+++ b/src/components/BodyCopy/BodyCopy.spec.js
@@ -16,7 +16,7 @@ describe('<BodyCopy />', () => {
     const tree = renderer
       .create(
         <BodyCopy
-          content={<p>{BodyCopyFixture.heading}</p>}
+          content={<div>{BodyCopyFixture.linkButtonGroup.children}</div>}
           copy="Parsley Seed Cream. [The Paris Review](http://theparisreview.org) Intensely soothing, nourishing and hydrating, this elegant formulation contains a potent blend of botanicals that offer fortification of the highest order against free radicals."
           eyebrow="Recommended Nearby"
           heading="Aesop & The Paris Review: A Partnership Extended"
@@ -26,6 +26,22 @@ describe('<BodyCopy />', () => {
       )
       .toJSON();
 
+    expect(tree).toMatchSnapshot();
+  });
+
+
+  it('does not render content when no `content` prop supplied', () => {
+    const tree = renderer
+      .create(
+        <BodyCopy
+          copy="Parsley Seed Cream. [The Paris Review](http://theparisreview.org) Intensely soothing, nourishing and hydrating, this elegant formulation contains a potent blend of botanicals that offer fortification of the highest order against free radicals."
+          eyebrow="Recommended Nearby"
+          heading="Aesop & The Paris Review: A Partnership Extended"
+          id="Anti-Oxidant"
+          subHeading="Active Nutrients"
+        />,
+      )
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/src/components/BodyCopy/BodyCopy.spec.js
+++ b/src/components/BodyCopy/BodyCopy.spec.js
@@ -29,7 +29,6 @@ describe('<BodyCopy />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-
   it('does not render content when no `content` prop supplied', () => {
     const tree = renderer
       .create(

--- a/src/components/BodyCopy/__snapshots__/BodyCopy.spec.js.snap
+++ b/src/components/BodyCopy/__snapshots__/BodyCopy.spec.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<BodyCopy /> does not render content when no \`content\` prop supplied 1`] = `
+<article
+  className="base dark"
+  id="Anti-Oxidant"
+>
+  <header
+    className="base"
+    id="Anti-Oxidant"
+  >
+    <h2
+      className="base mediumWeightFont xXSmall dark eyebrow"
+    >
+      Recommended Nearby
+    </h2>
+    <h3
+      className="base xLarge dark heading"
+    >
+      Aesop & The Paris Review: A Partnership Extended
+    </h3>
+    <h4
+      className="base mediumWeightFont xSmall dark subHeading"
+    >
+      Active Nutrients
+    </h4>
+  </header>
+  <div
+    className="copy"
+  >
+    Parsley Seed Cream. [The Paris Review](http://theparisreview.org) Intensely soothing, nourishing and hydrating, this elegant formulation contains a potent blend of botanicals that offer fortification of the highest order against free radicals.
+  </div>
+</article>
+`;
+
 exports[`<BodyCopy /> renders base component correctly 1`] = `
 <article
   className="base dark"
@@ -33,9 +66,22 @@ exports[`<BodyCopy /> renders base component correctly 1`] = `
   <div
     className="contentWrapper"
   >
-    <p>
-      Lorem ipsum dolor sit amet
-    </p>
+    <div>
+      <a
+        className="base blockStyle left dark"
+        href="/"
+        target="_self"
+      >
+        Proin vulputate
+      </a>
+      <a
+        className="base blockStyle left dark"
+        href="Quisque lacus"
+        target="_self"
+      >
+        Quisque lacus
+      </a>
+    </div>
   </div>
 </article>
 `;

--- a/src/components/LinkButtonGroup/LinkButtonGroup.spec.js
+++ b/src/components/LinkButtonGroup/LinkButtonGroup.spec.js
@@ -19,4 +19,16 @@ describe('<LinkButtonGroup />', () => {
 
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders children correctly', () => {
+    const tree = renderer
+      .create(
+        <LinkButtonGroup theme="light">
+          <a href="/au/r/about">Link</a>
+        </LinkButtonGroup>,
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/LinkButtonGroup/__snapshots__/LinkButtonGroup.spec.js.snap
+++ b/src/components/LinkButtonGroup/__snapshots__/LinkButtonGroup.spec.js.snap
@@ -1,3 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<LinkButtonGroup /> renders base component correctly 1`] = `null`;
+
+exports[`<LinkButtonGroup /> renders children correctly 1`] = `
+<div
+  className="base flush"
+>
+  <a
+    className=" link flushLink center"
+    href="/au/r/about"
+    textAlign="center"
+    theme="light"
+  >
+    Link
+  </a>
+</div>
+`;


### PR DESCRIPTION
Updating tests for PR: https://github.com/aesop/aesop-gel/pull/103

> #### Ticket
> https://aesoponline.atlassian.net/browse/AES-1552
> 
> #### Summary
> Updates to `<BodyCopy />`:
> 
> * Remove content display logic of `cta` `secondaryCta` `linkList`
> * Decided to have display logic handled in web-ui

