### PR TITLE
[Feature/AES-1695-product-item]: Product Grid Item

### DIFF
--- a/src/components/DefinitionList/DefinitionList.module.css
+++ b/src/components/DefinitionList/DefinitionList.module.css
@@ -13,7 +13,7 @@
 
 .term,
 .description {
-  font-size: rem(15px);
+  font-size: rem(14px);
   line-height: 1.4;
   opacity: 0;
   transform: translateY(-20px);

--- a/src/components/ProductGridItem/ProductGridItem.fixture.js
+++ b/src/components/ProductGridItem/ProductGridItem.fixture.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/components/ProductGridItem/ProductGridItem.fixture.js
+++ b/src/components/ProductGridItem/ProductGridItem.fixture.js
@@ -1,1 +1,64 @@
-export default {};
+export default {
+  variantOptions: [
+    {
+      size: '50 mL - In stock',
+      sku: 'ARD33',
+      price: '$26.45',
+      isInStock: true,
+      image: {
+        altText: 'alt-tag-ARD33',
+        sizes: {
+          large: './assets/images/Product/variant-one-large.png',
+          medium: './assets/images/Product/variant-one-medium.png',
+          small: './assets/images/Product/variant-one-small.png',
+        },
+      },
+    },
+    {
+      size: '100 mL - Not in stock',
+      sku: 'ARD32',
+      price: '$86.97',
+      isInStock: false,
+      image: {
+        altText: 'alt-tag-ARD32',
+        sizes: {
+          large: './assets/images/Product/variant-two-large.png',
+          medium: './assets/images/Product/variant-two-medium.png',
+          small: './assets/images/Product/variant-two-small.png',
+        },
+      },
+    },
+    {
+      size: '180 mL - In stock',
+      sku: 'ARD30',
+      price: '$96.97',
+      isInStock: true,
+      image: {
+        altText: 'alt-tag-ARD32',
+        sizes: {
+          large: './assets/images/Product/variant-two-large.png',
+          medium: './assets/images/Product/variant-two-medium.png',
+          small: './assets/images/Product/variant-two-small.png',
+        },
+      },
+    },
+    {
+      alternateAction: {
+        url: '/?searchMenu=open',
+        label: 'Visit Store - $89.45',
+      },
+      size: '500 mL - Alternate action',
+      sku: 'ARD31',
+      price: '$109.45',
+      isInStock: true,
+      image: {
+        altText: 'alt-tag-ARD31',
+        sizes: {
+          large: './assets/images/Product/variant-two-large.png',
+          medium: './assets/images/Product/variant-two-medium.png',
+          small: './assets/images/Product/variant-two-small.png',
+        },
+      },
+    },
+  ],
+};

--- a/src/components/ProductGridItem/ProductGridItem.fixture.js
+++ b/src/components/ProductGridItem/ProductGridItem.fixture.js
@@ -1,5 +1,21 @@
 export default {
   info: '4 Sizes / From $ 26.45',
+  variantOptionsOneItem: [
+    {
+      size: '50 mL - In stock',
+      sku: 'ARD33',
+      price: '$26.45',
+      isInStock: true,
+      image: {
+        altText: 'alt-tag-ARD33',
+        sizes: {
+          large: './assets/images/Product/variant-one-large.png',
+          medium: './assets/images/Product/variant-one-medium.png',
+          small: './assets/images/Product/variant-one-small.png',
+        },
+      },
+    },
+  ],
   variantOptions: [
     {
       size: '50 mL - In stock',
@@ -36,24 +52,6 @@ export default {
       isInStock: true,
       image: {
         altText: 'alt-tag-ARD32',
-        sizes: {
-          large: './assets/images/Product/variant-two-large.png',
-          medium: './assets/images/Product/variant-two-medium.png',
-          small: './assets/images/Product/variant-two-small.png',
-        },
-      },
-    },
-    {
-      alternateAction: {
-        url: '/?searchMenu=open',
-        label: 'Visit Store - $89.45',
-      },
-      size: '500 mL - Alternate action',
-      sku: 'ARD31',
-      price: '$109.45',
-      isInStock: true,
-      image: {
-        altText: 'alt-tag-ARD31',
         sizes: {
           large: './assets/images/Product/variant-two-large.png',
           medium: './assets/images/Product/variant-two-medium.png',

--- a/src/components/ProductGridItem/ProductGridItem.fixture.js
+++ b/src/components/ProductGridItem/ProductGridItem.fixture.js
@@ -1,4 +1,5 @@
 export default {
+  info: '4 Sizes / From $ 26.45',
   variantOptions: [
     {
       size: '50 mL - In stock',

--- a/src/components/ProductGridItem/ProductGridItem.fixture.js
+++ b/src/components/ProductGridItem/ProductGridItem.fixture.js
@@ -61,4 +61,5 @@ export default {
       },
     },
   ],
+  url: '/p/',
 };

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -78,7 +78,7 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
       </Heading>
 
       <div className={styles.infoVariantHolder}>
-        <Hidden isSmall={!hasOneVariant}>
+        <Hidden isMedium={!hasOneVariant} isSmall={!hasOneVariant}>
           <div className={classInfoHolderSet}>
             <P className={styles.info} theme={theme}>
               {info}
@@ -87,7 +87,7 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
         </Hidden>
 
         {!hasOneVariant && (
-          <Hidden isMedium={true}>
+          <Hidden isMedium={false}>
             <RadioGroup
               className={styles.variants}
               dataTestRef={RADIO_GROUP_DATA_TEST_REF}
@@ -101,7 +101,7 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
         )}
       </div>
 
-      <Hidden isMedium={true}>
+      <Hidden isMedium={false}>
         <AddToCartButton
           className={styles.addToCartButton}
           copy={copy.addToCart}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -10,14 +10,16 @@ import { getVariantRadioOptions } from '~/utils/product';
 import AddToCartButton from '~/components/AddToCartButton';
 import DefinitionList from '~/components/DefinitionList';
 import Heading from '~/components/Heading';
+import Hidden from '~/components/Hidden';
 import Hyperlink from '~/components/Hyperlink';
 import Image from '~/components/Image';
 import RadioGroup from '~/components/RadioGroup';
 import Transition from '~/components/Transition';
+import { P } from '~/components/Paragraph';
 
 import styles from './ProductGridItem.module.css';
 
-const ProductGridItem = ({ className, copy, theme, url }) => {
+const ProductGridItem = ({ className, copy, info, theme, url }) => {
   const imageRef = useRef();
   const {
     selectedVariant,
@@ -37,7 +39,7 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
   const { definitionList, productName } = productDetail;
 
   const variantRadioOptions = getVariantRadioOptions(variants);
-  const classSet = cx(styles.base, className);
+  const classSet = cx(styles.base, styles[theme], className);
 
   const RADIO_GROUP_NAME = 'sku';
   const RADIO_GROUP_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_VARIANT_SELECT';
@@ -68,23 +70,31 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
         </Hyperlink>
       </Heading>
 
-      <RadioGroup
-        className={styles.variants}
-        dataTestRef={RADIO_GROUP_DATA_TEST_REF}
-        name={RADIO_GROUP_NAME}
-        onChange={e => onVariantChange(e, variants)}
-        options={variantRadioOptions}
-        theme={theme}
-        value={selectedVariant.sku}
-      />
+      <Hidden isMedium={true}>
+        <RadioGroup
+          className={styles.variants}
+          dataTestRef={RADIO_GROUP_DATA_TEST_REF}
+          name={RADIO_GROUP_NAME}
+          onChange={e => onVariantChange(e, variants)}
+          options={variantRadioOptions}
+          theme={theme}
+          value={selectedVariant.sku}
+        />
+      </Hidden>
 
-      <AddToCartButton
-        className={styles.addToCartButton}
-        copy={copy.addToCart}
-        dataTestRef={ADD_TO_CART_BUTTON_DATA_TEST_REF}
-        isFullWidth={true}
-        theme={theme}
-      />
+      <P className={styles.info} theme={theme}>
+        {info}
+      </P>
+
+      <Hidden isMedium={true}>
+        <AddToCartButton
+          className={styles.addToCartButton}
+          copy={copy.addToCart}
+          dataTestRef={ADD_TO_CART_BUTTON_DATA_TEST_REF}
+          isFullWidth={true}
+          theme={theme}
+        />
+      </Hidden>
 
       <DefinitionList
         className={styles.definitionList}
@@ -108,6 +118,7 @@ ProductGridItem.propTypes = {
       }),
     }),
   }),
+  info: PropTypes.string,
   theme: PropTypes.oneOf(['dark', 'light']),
   url: PropTypes.string,
 };
@@ -124,6 +135,7 @@ ProductGridItem.defaultProps = {
       },
     },
   },
+  info: undefined,
   theme: 'dark',
   url: undefined,
 };

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
+// import { useVariantSelectContext } from '~/contexts';
+import AddToCartButton from '~/components/AddToCartButton';
+
 import styles from './ProductGridItem.module.css';
 
-const ProductGridItem = ({ className }) => {
+const ProductGridItem = ({ className, copy, theme }) => {
+  // const {
+  //   selectedVariant,
+  //   onVariantChange,
+  //   variants,
+  // } = useVariantSelectContext();
+
   const classSet = cx(styles.base, className);
+
+  const ADD_TO_CART_BUTTON_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_ADD_TO_CART_CTA';
 
   return (
     <div className={classSet}>
@@ -12,7 +24,16 @@ const ProductGridItem = ({ className }) => {
       <p>Image</p>
       <p>Product title</p>
       <p>radio buttons</p>
+
       <p>Button add to cart</p>
+      <AddToCartButton
+        className={styles.addToCartButton}
+        copy={copy.addToCart}
+        dataTestRef={ADD_TO_CART_BUTTON_DATA_TEST_REF}
+        isFullWidth={false}
+        theme={theme}
+      />
+
       <p>list items</p>
     </div>
   );
@@ -20,10 +41,32 @@ const ProductGridItem = ({ className }) => {
 
 ProductGridItem.propTypes = {
   className: PropTypes.string,
+  copy: PropTypes.shape({
+    addToCart: PropTypes.shape({
+      cartAction: PropTypes.string,
+      updateNotification: PropTypes.string,
+      outOfStock: PropTypes.shape({
+        label: PropTypes.string,
+        title: PropTypes.string,
+      }),
+    }),
+  }),
+  theme: PropTypes.oneOf(['dark', 'light']),
 };
 
 ProductGridItem.defaultProps = {
   className: undefined,
+  copy: {
+    addToCart: {
+      cartAction: undefined,
+      updateNotification: undefined,
+      outOfStock: {
+        label: undefined,
+        title: undefined,
+      },
+    },
+  },
+  theme: 'dark',
 };
 
 export default ProductGridItem;

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -4,19 +4,22 @@ import cx from 'classnames';
 
 import { HEADING } from '~/constants';
 import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
+import { getVariantRadioOptions } from '~/utils/product';
+
 import AddToCartButton from '~/components/AddToCartButton';
-import Hyperlink from '~/components/Hyperlink';
-import Heading from '~/components/Heading';
 import DefinitionList from '~/components/DefinitionList';
+import Heading from '~/components/Heading';
+import Hyperlink from '~/components/Hyperlink';
+import RadioGroup from '~/components/RadioGroup';
 
 import styles from './ProductGridItem.module.css';
 
 const ProductGridItem = ({ className, copy, theme, url }) => {
-  // const {
-  //   selectedVariant,
-  //   onVariantChange,
-  //   variants,
-  // } = useVariantSelectContext();
+  const {
+    selectedVariant,
+    onVariantChange,
+    variants,
+  } = useVariantSelectContext();
 
   const { productDetail } = useProductDetailContext();
 
@@ -24,8 +27,11 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
 
   const { definitionList, productName } = productDetail;
 
+  const variantRadioOptions = getVariantRadioOptions(variants);
   const classSet = cx(styles.base, className);
 
+  const RADIO_GROUP_NAME = 'sku';
+  const RADIO_GROUP_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_VARIANT_SELECT';
   const ADD_TO_CART_BUTTON_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_ADD_TO_CART_CTA';
 
   return (
@@ -34,7 +40,6 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
       <p>Image</p>
 
       <Heading
-        className={styles.productName}
         hasMediumWeightFont={true}
         level={HEADING.LEVEL.FIVE}
         size={HEADING.SIZE.X_X_SMALL}
@@ -45,7 +50,15 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
         </Hyperlink>
       </Heading>
 
-      <p>radio buttons</p>
+      <RadioGroup
+        className={styles.variants}
+        dataTestRef={RADIO_GROUP_DATA_TEST_REF}
+        name={RADIO_GROUP_NAME}
+        onChange={e => onVariantChange(e, variants)}
+        options={variantRadioOptions}
+        theme={theme}
+        value={selectedVariant.sku}
+      />
 
       <AddToCartButton
         className={styles.addToCartButton}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -48,14 +48,16 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
   return (
     <div className={classSet}>
       <Transition isActive={isImageActive} name="fade">
-        <Image
-          altText={currentImage.altText}
-          className={styles.image}
-          large={currentImage.sizes?.large}
-          medium={currentImage.sizes?.medium}
-          ref={imageRef}
-          small={currentImage.sizes?.small}
-        />
+        <Hyperlink className={styles.imageLink} url={url}>
+          <Image
+            altText={currentImage.altText}
+            className={styles.image}
+            large={currentImage.sizes?.large}
+            medium={currentImage.sizes?.medium}
+            ref={imageRef}
+            small={currentImage.sizes?.small}
+          />
+        </Hyperlink>
       </Transition>
 
       <Heading

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-// import { useVariantSelectContext } from '~/contexts';
+import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
 import AddToCartButton from '~/components/AddToCartButton';
+import DefinitionList from '~/components/DefinitionList';
 
 import styles from './ProductGridItem.module.css';
 
@@ -14,27 +15,35 @@ const ProductGridItem = ({ className, copy, theme }) => {
   //   variants,
   // } = useVariantSelectContext();
 
+  const { productDetail } = useProductDetailContext();
+  const { definitionList } = productDetail;
+
   const classSet = cx(styles.base, className);
 
   const ADD_TO_CART_BUTTON_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_ADD_TO_CART_CTA';
 
   return (
     <div className={classSet}>
-      <p>Product grid item - mobile first</p>
+      <h3>Product grid item - mobile first</h3>
       <p>Image</p>
       <p>Product title</p>
       <p>radio buttons</p>
 
-      <p>Button add to cart</p>
       <AddToCartButton
         className={styles.addToCartButton}
         copy={copy.addToCart}
         dataTestRef={ADD_TO_CART_BUTTON_DATA_TEST_REF}
-        isFullWidth={false}
+        isFullWidth={true}
         theme={theme}
       />
 
-      <p>list items</p>
+
+      <DefinitionList
+        className={styles.definitionList}
+        hasBottomBorder={true}
+        items={definitionList}
+        theme={theme}
+      />
     </div>
   );
 };

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -27,6 +27,8 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
     variants,
   } = useVariantSelectContext();
 
+  const hasOneVariant = variants.length === 1;
+
   const [currentImage, isImageActive] = useImageTransition(
     selectedVariant?.image,
     imageRef,
@@ -72,21 +74,27 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
         </Hyperlink>
       </Heading>
 
-      <Hidden isMedium={true}>
-        <RadioGroup
-          className={styles.variants}
-          dataTestRef={RADIO_GROUP_DATA_TEST_REF}
-          name={RADIO_GROUP_NAME}
-          onChange={e => onVariantChange(e, variants)}
-          options={variantRadioOptions}
-          theme={theme}
-          value={selectedVariant.sku}
-        />
-      </Hidden>
+      {!hasOneVariant && (
+        <Hidden isMedium={true}>
+          <RadioGroup
+            className={styles.variants}
+            dataTestRef={RADIO_GROUP_DATA_TEST_REF}
+            name={RADIO_GROUP_NAME}
+            onChange={e => onVariantChange(e, variants)}
+            options={variantRadioOptions}
+            theme={theme}
+            value={selectedVariant.sku}
+          />
+        </Hidden>
+      )}
 
-      <P className={styles.info} theme={theme}>
-        {info}
-      </P>
+      <Hidden isSmall={!hasOneVariant}>
+        <div className={styles.infoHolder}>
+          <P className={styles.info} theme={theme}>
+            {info}
+          </P>
+        </div>
+      </Hidden>
 
       <Hidden isMedium={true}>
         <AddToCartButton

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -42,6 +42,9 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
 
   const variantRadioOptions = getVariantRadioOptions(variants);
   const classSet = cx(styles.base, styles[theme], className);
+  const classInfoHolderSet = cx(styles.infoHolder, {
+    [styles.hasOneVariant]: hasOneVariant,
+  });
 
   const RADIO_GROUP_NAME = 'sku';
   const RADIO_GROUP_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_VARIANT_SELECT';
@@ -74,27 +77,29 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
         </Hyperlink>
       </Heading>
 
-      {!hasOneVariant && (
-        <Hidden isMedium={true}>
-          <RadioGroup
-            className={styles.variants}
-            dataTestRef={RADIO_GROUP_DATA_TEST_REF}
-            name={RADIO_GROUP_NAME}
-            onChange={e => onVariantChange(e, variants)}
-            options={variantRadioOptions}
-            theme={theme}
-            value={selectedVariant.sku}
-          />
+      <div className={styles.infoVariantHolder}>
+        <Hidden isSmall={!hasOneVariant}>
+          <div className={classInfoHolderSet}>
+            <P className={styles.info} theme={theme}>
+              {info}
+            </P>
+          </div>
         </Hidden>
-      )}
 
-      <Hidden isSmall={!hasOneVariant}>
-        <div className={styles.infoHolder}>
-          <P className={styles.info} theme={theme}>
-            {info}
-          </P>
-        </div>
-      </Hidden>
+        {!hasOneVariant && (
+          <Hidden isMedium={true}>
+            <RadioGroup
+              className={styles.variants}
+              dataTestRef={RADIO_GROUP_DATA_TEST_REF}
+              name={RADIO_GROUP_NAME}
+              onChange={e => onVariantChange(e, variants)}
+              options={variantRadioOptions}
+              theme={theme}
+              value={selectedVariant.sku}
+            />
+          </Hidden>
+        )}
+      </div>
 
       <Hidden isMedium={true}>
         <AddToCartButton

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -19,7 +19,7 @@ import { P } from '~/components/Paragraph';
 
 import styles from './ProductGridItem.module.css';
 
-const ProductGridItem = ({ className, copy, info, theme, url }) => {
+const ProductGridItem = ({ className, copy, id, info, theme, url }) => {
   const imageRef = useRef();
   const {
     selectedVariant,
@@ -51,7 +51,7 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
   const ADD_TO_CART_BUTTON_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_ADD_TO_CART_CTA';
 
   return (
-    <div className={classSet}>
+    <div className={classSet} id={id}>
       <Transition isActive={isImageActive} name="fade">
         <Hyperlink className={styles.imageLink} url={url}>
           <Image
@@ -133,6 +133,7 @@ ProductGridItem.propTypes = {
       }),
     }),
   }),
+  id: PropTypes.string,
   info: PropTypes.string,
   theme: PropTypes.oneOf(['dark', 'light']),
   url: PropTypes.string,
@@ -150,6 +151,7 @@ ProductGridItem.defaultProps = {
       },
     },
   },
+  id: undefined,
   info: undefined,
   theme: 'dark',
   url: undefined,

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
+import styles from './ProductGridItem.module.css';
 
-const ProductGridItem = () => {
+const ProductGridItem = ({ className }) => {
+  const classSet = cx(styles.base, className);
+
   return (
-    <div>
+    <div className={classSet}>
       <p>Product grid item - mobile first</p>
       <p>Image</p>
       <p>Product title</p>
@@ -14,8 +18,12 @@ const ProductGridItem = () => {
   );
 };
 
-ProductGridItem.propTypes = {};
+ProductGridItem.propTypes = {
+  className: PropTypes.string,
+};
 
-ProductGridItem.defaultProps = {};
+ProductGridItem.defaultProps = {
+  className: undefined,
+};
 
 export default ProductGridItem;

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -27,7 +27,7 @@ const ProductGridItem = ({ className, copy, info, theme, url }) => {
     variants,
   } = useVariantSelectContext();
 
-  const hasOneVariant = variants.length === 1;
+  const hasOneVariant = variants?.length === 1;
 
   const [currentImage, isImageActive] = useImageTransition(
     selectedVariant?.image,

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -5,12 +5,13 @@ import cx from 'classnames';
 import { HEADING } from '~/constants';
 import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
 import AddToCartButton from '~/components/AddToCartButton';
+import Hyperlink from '~/components/Hyperlink';
 import Heading from '~/components/Heading';
 import DefinitionList from '~/components/DefinitionList';
 
 import styles from './ProductGridItem.module.css';
 
-const ProductGridItem = ({ className, copy, theme }) => {
+const ProductGridItem = ({ className, copy, theme, url }) => {
   // const {
   //   selectedVariant,
   //   onVariantChange,
@@ -39,7 +40,9 @@ const ProductGridItem = ({ className, copy, theme }) => {
         size={HEADING.SIZE.X_X_SMALL}
         theme={theme}
       >
-        {productName}
+        <Hyperlink className={styles.productNameLink} url={url}>
+          {productName}
+        </Hyperlink>
       </Heading>
 
       <p>radio buttons</p>
@@ -75,6 +78,7 @@ ProductGridItem.propTypes = {
     }),
   }),
   theme: PropTypes.oneOf(['dark', 'light']),
+  url: PropTypes.string,
 };
 
 ProductGridItem.defaultProps = {
@@ -90,6 +94,7 @@ ProductGridItem.defaultProps = {
     },
   },
   theme: 'dark',
+  url: undefined,
 };
 
 export default ProductGridItem;

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ProductGridItem = ({ prop }) => {
+const ProductGridItem = () => {
   return (
     <div>
       <p>Product grid item - mobile first</p>

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -1,25 +1,34 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { HEADING } from '~/constants';
 import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
+import { useImageTransition } from '~/customHooks';
 import { getVariantRadioOptions } from '~/utils/product';
 
 import AddToCartButton from '~/components/AddToCartButton';
 import DefinitionList from '~/components/DefinitionList';
 import Heading from '~/components/Heading';
 import Hyperlink from '~/components/Hyperlink';
+import Image from '~/components/Image';
 import RadioGroup from '~/components/RadioGroup';
+import Transition from '~/components/Transition';
 
 import styles from './ProductGridItem.module.css';
 
 const ProductGridItem = ({ className, copy, theme, url }) => {
+  const imageRef = useRef();
   const {
     selectedVariant,
     onVariantChange,
     variants,
   } = useVariantSelectContext();
+
+  const [currentImage, isImageActive] = useImageTransition(
+    selectedVariant?.image,
+    imageRef,
+  );
 
   const { productDetail } = useProductDetailContext();
 
@@ -36,8 +45,16 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
 
   return (
     <div className={classSet}>
-      <h3>Product grid item - mobile first</h3>
-      <p>Image</p>
+      <Transition isActive={isImageActive} name="fade">
+        <Image
+          altText={currentImage.altText}
+          className={styles.image}
+          large={currentImage.sizes?.large}
+          medium={currentImage.sizes?.medium}
+          ref={imageRef}
+          small={currentImage.sizes?.small}
+        />
+      </Transition>
 
       <Heading
         className={styles.productName}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -37,7 +37,6 @@ const ProductGridItem = ({ className, copy, theme }) => {
         theme={theme}
       />
 
-
       <DefinitionList
         className={styles.definitionList}
         hasBottomBorder={true}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
+import { HEADING } from '~/constants';
 import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
 import AddToCartButton from '~/components/AddToCartButton';
+import Heading from '~/components/Heading';
 import DefinitionList from '~/components/DefinitionList';
 
 import styles from './ProductGridItem.module.css';
@@ -16,7 +18,10 @@ const ProductGridItem = ({ className, copy, theme }) => {
   // } = useVariantSelectContext();
 
   const { productDetail } = useProductDetailContext();
-  const { definitionList } = productDetail;
+
+  if (!productDetail) return null;
+
+  const { definitionList, productName } = productDetail;
 
   const classSet = cx(styles.base, className);
 
@@ -26,7 +31,17 @@ const ProductGridItem = ({ className, copy, theme }) => {
     <div className={classSet}>
       <h3>Product grid item - mobile first</h3>
       <p>Image</p>
-      <p>Product title</p>
+
+      <Heading
+        className={styles.productName}
+        hasMediumWeightFont={true}
+        level={HEADING.LEVEL.FIVE}
+        size={HEADING.SIZE.X_X_SMALL}
+        theme={theme}
+      >
+        {productName}
+      </Heading>
+
       <p>radio buttons</p>
 
       <AddToCartButton

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -40,6 +40,7 @@ const ProductGridItem = ({ className, copy, theme, url }) => {
       <p>Image</p>
 
       <Heading
+        className={styles.productName}
         hasMediumWeightFont={true}
         level={HEADING.LEVEL.FIVE}
         size={HEADING.SIZE.X_X_SMALL}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ProductGridItem = ({ prop }) => {
+  return (
+    <div>
+      <p>Product grid item - mobile first</p>
+      <p>Image</p>
+      <p>Product title</p>
+      <p>radio buttons</p>
+      <p>Button add to cart</p>
+      <p>list items</p>
+    </div>
+  );
+};
+
+ProductGridItem.propTypes = {};
+
+ProductGridItem.defaultProps = {};
+
+export default ProductGridItem;

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,17 +1,22 @@
 @import 'styles/index';
 
 .base {
-  padding: 20px;
-  background-color: papayawhip;
+  @media (--viewport-sm-only) {
+    padding: 20px;
+  }
+
+  @media (--viewport-md-only) {
+    padding: var(--layout-md-spacing);
+  }
+
+  @media (--viewport-lg) {
+    padding: var(--layout-lg-spacing);
+  }
 }
 
 .image {
   display: flex;
   justify-content: center;
-
-  @media (--viewport-md) {
-    justify-content: flex-end;
-  }
 
   img {
     width: auto;

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -4,6 +4,8 @@
   background-color: papayawhip;
 }
 
+/* .productName { } */
+
 .definitionList {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,6 +1,8 @@
 @import 'styles/index';
 
 .base {
+  transition: background-color 300ms var(--easing-ease-out-cubic);
+
   @media (--viewport-sm-only) {
     padding: var(--layout-lg-spacing) 20px;
   }
@@ -16,7 +18,23 @@
   }
 
   @media (--viewport-lg) {
-    padding: var(--layout-lg-spacing);
+    position: relative;
+    width: 460px; /* Temporary for local development */
+    padding: var(--layout-lg-spacing) var(--layout-lg-spacing) 65px;
+    /* background-color: papayawhip; */
+
+    &:hover {
+      background-color: #f0efe1;
+
+      .variants,
+      .addToCartButton {
+        opacity: 1;
+      }
+
+      .infoHolder:not(.hasOneVariant) {
+        opacity: 0;
+      }
+    }
   }
 }
 
@@ -26,8 +44,16 @@
 
   @media (--viewport-md-only) {
     height: 280px;
+  }
+
+  @media (--viewport-md) {
     align-items: flex-end;
-    background-color: lightblue;
+    /* background-color: lightblue; */
+  }
+
+  @media (--viewport-lg) {
+    height: 440px;
+    padding-top: 80px;
   }
 
   img {
@@ -55,8 +81,24 @@
   color: currentColor;
 }
 
+@media (--viewport-lg) {
+  .infoVariantHolder {
+    height: 60px;
+
+    &:focus-within .infoHolder {
+      opacity: 0;
+    }
+  }
+}
+
 .infoHolder {
-  margin-bottom: var(--layout-sm-spacing);
+  @media (--viewport-sm-md-only) {
+    margin-bottom: var(--layout-sm-spacing);
+    opacity: 1;
+  }
+  @media (--viewport-lg) {
+    transition: opacity 300ms var(--easing-ease-out-cubic);
+  }
 }
 
 .info {
@@ -66,7 +108,34 @@
 }
 
 .variants {
-  margin-bottom: 24px;
+  @media (--viewport-sm-md-only) {
+    margin-bottom: 24px;
+  }
+  @media (--viewport-lg) {
+    position: relative;
+    z-index: 2;
+    margin-top: -26px;
+    opacity: 0;
+    transition: opacity 300ms var(--easing-ease-out-cubic);
+
+    &:focus-within {
+      opacity: 1;
+    }
+  }
+}
+
+.addToCartButton {
+  @media (--viewport-lg) {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+
+    &:focus {
+      opacity: 1;
+    }
+  }
 }
 
 .definitionList {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -13,17 +13,15 @@
   }
 
   @media (--viewport-md-only) {
-    width: 50%; /* Temporary for local development */
-    padding: 100px var(--layout-md-spacing) var(--layout-md-spacing);
+    padding: var(--layout-md-spacing);
   }
 
   @media (--viewport-lg) {
     position: relative;
-    width: 460px; /* Temporary for local development */
     padding: var(--layout-lg-spacing) var(--layout-lg-spacing) 65px;
 
     &:hover {
-      background-color: #f0efe1;
+      background-color: var(--color-white-darker-2);
 
       .variants,
       .addToCartButton {
@@ -42,7 +40,8 @@
   justify-content: center;
 
   @media (--viewport-md-only) {
-    height: 280px;
+    height: 330px;
+    padding-top: 80px;
   }
 
   @media (--viewport-md) {
@@ -50,8 +49,8 @@
   }
 
   @media (--viewport-lg) {
-    height: 440px;
-    padding-top: 80px;
+    height: 420px;
+    padding-top: 110px;
   }
 
   img {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -80,7 +80,7 @@
 
 @media (--viewport-lg) {
   .infoVariantHolder {
-    height: 60px;
+    min-height: 60px;
 
     &:focus-within .infoHolder {
       opacity: 0;

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -4,9 +4,12 @@
   background-color: papayawhip;
 }
 
-/* .productName { } */
 .productNameLink {
   color: currentColor;
+}
+
+.variants {
+  margin-bottom: 24px;
 }
 
 .definitionList {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -4,6 +4,10 @@
   background-color: papayawhip;
 }
 
+.productName {
+  text-align: center;
+}
+
 .productNameLink {
   color: currentColor;
 }

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,4 +1,5 @@
 @import 'styles/index';
 
 .base {
+  background-color: papayawhip;
 }

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -136,7 +136,9 @@
 }
 
 .definitionList {
+  display: -ms-grid;
   display: grid;
+  -ms-grid-columns: auto minmax(0, 1fr);
   grid-template-columns: auto minmax(0, 1fr);
 
   @media (--viewport-lg) {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -5,8 +5,13 @@
     padding: var(--layout-lg-spacing) 20px;
   }
 
+  &,
+  & * {
+    box-sizing: border-box;
+  }
+
   @media (--viewport-md-only) {
-    width: 45%; /* Temporary for local development */
+    width: 50%; /* Temporary for local development */
     padding: 100px var(--layout-md-spacing) var(--layout-md-spacing);
   }
 
@@ -36,6 +41,10 @@
       max-height: 100%;
     }
   }
+}
+
+.imageLink {
+  display: block;
 }
 
 .productName {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -5,6 +5,9 @@
 }
 
 /* .productName { } */
+.productNameLink {
+  color: currentColor;
+}
 
 .definitionList {
   display: grid;

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -2,29 +2,38 @@
 
 .base {
   @media (--viewport-sm-only) {
-    padding: 20px;
+    padding: var(--layout-lg-spacing) 20px;
   }
 
   @media (--viewport-md-only) {
-    padding: var(--layout-md-spacing);
+    width: 45%; /* Temporary for local development */
+    padding: 100px var(--layout-md-spacing) var(--layout-md-spacing);
   }
 
   @media (--viewport-lg) {
     padding: var(--layout-lg-spacing);
   }
+
+  background-color: papayawhip;
 }
 
 .image {
   display: flex;
   justify-content: center;
 
+  @media (--viewport-md-only) {
+    height: 280px;
+    align-items: flex-end;
+    background-color: lightblue;
+  }
+
   img {
     width: auto;
     max-width: 100%;
-    max-height: 300px;
+    max-height: 250px;
 
     @media (--viewport-md) {
-      max-height: 400px;
+      max-height: 100%;
     }
   }
 }
@@ -39,6 +48,12 @@
   color: currentColor;
 }
 
+.info {
+  color: var(--color-grey-30);
+  font-size: rem(14px);
+  text-align: center;
+}
+
 .variants {
   margin-bottom: 24px;
 }
@@ -46,6 +61,16 @@
 .definitionList {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
+
+  @media (--viewport-md) {
+    .dark & {
+      border-top: 2px solid var(--color-grey-20);
+    }
+
+    .light & {
+      border-top: 2px solid var(--color-light-copy);
+    }
+  }
 
   dt {
     padding-right: 20px;
@@ -59,7 +84,15 @@
     padding-bottom: 14px;
   }
 
+  dt:nth-of-type(1) {
+    @media (--viewport-md) {
+      padding-top: 14px;
+    }
+  }
+
   dd:nth-of-type(1) {
-    padding-top: 0;
+    @media (--viewport-sm-only) {
+      padding-top: 0;
+    }
   }
 }

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -3,3 +3,24 @@
 .base {
   background-color: papayawhip;
 }
+
+.definitionList {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+
+  dt {
+    padding-right: 20px;
+    border-bottom: 1px solid var(--color-grey-65);
+    margin-bottom: 0;
+  }
+
+  dt,
+  dd {
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+
+  dd:nth-of-type(1) {
+    padding-top: 0;
+  }
+}

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,0 +1,4 @@
+@import 'styles/index';
+
+.base {
+}

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -18,8 +18,6 @@
   @media (--viewport-lg) {
     padding: var(--layout-lg-spacing);
   }
-
-  background-color: papayawhip;
 }
 
 .image {
@@ -55,6 +53,10 @@
 
 .productNameLink {
   color: currentColor;
+}
+
+.infoHolder {
+  margin-bottom: var(--layout-sm-spacing);
 }
 
 .info {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -139,7 +139,7 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
 
-  @media (--viewport-md) {
+  @media (--viewport-lg) {
     .dark & {
       border-top: 2px solid var(--color-grey-20);
     }
@@ -162,13 +162,13 @@
   }
 
   dt:nth-of-type(1) {
-    @media (--viewport-md) {
+    @media (--viewport-lg) {
       padding-top: 14px;
     }
   }
 
   dd:nth-of-type(1) {
-    @media (--viewport-sm-only) {
+    @media (--viewport-sm-md-only) {
       padding-top: 0;
     }
   }

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -21,7 +21,6 @@
     position: relative;
     width: 460px; /* Temporary for local development */
     padding: var(--layout-lg-spacing) var(--layout-lg-spacing) 65px;
-    /* background-color: papayawhip; */
 
     &:hover {
       background-color: #f0efe1;
@@ -48,7 +47,6 @@
 
   @media (--viewport-md) {
     align-items: flex-end;
-    /* background-color: lightblue; */
   }
 
   @media (--viewport-lg) {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,10 +1,32 @@
 @import 'styles/index';
 
 .base {
+  padding: 20px;
   background-color: papayawhip;
 }
 
+.image {
+  display: flex;
+  justify-content: center;
+
+  @media (--viewport-md) {
+    justify-content: flex-end;
+  }
+
+  img {
+    width: auto;
+    max-width: 100%;
+    max-height: 300px;
+
+    @media (--viewport-md) {
+      max-height: 400px;
+    }
+  }
+}
+
 .productName {
+  margin-top: 0;
+  margin-bottom: 7px;
   text-align: center;
 }
 

--- a/src/components/ProductGridItem/ProductGridItem.spec.js
+++ b/src/components/ProductGridItem/ProductGridItem.spec.js
@@ -2,6 +2,12 @@ import React from 'react';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import renderer from 'react-test-renderer';
+import {
+  ProductDetailContextProvider,
+  VariantSelectContextProvider,
+} from '~/contexts';
+import ProductDetailHeaderFixture from '~/components/ProductDetailHeader/ProductDetailHeader.fixture';
+import AddToCartButtonFixture from '~/components/AddToCartButton/AddToCartButton.fixture';
 import ProductGridItem from './ProductGridItem';
 import ProductGridItemFixture from './ProductGridItem.fixture';
 
@@ -13,7 +19,26 @@ describe('<ProductGridItem />', () => {
   });
 
   it('renders base component correctly', () => {
-    const tree = renderer.create(<ProductGridItem />).toJSON();
+    const tree = renderer
+      .create(
+        <ProductDetailContextProvider
+          product={ProductDetailHeaderFixture.product}
+        >
+          <VariantSelectContextProvider
+            variants={ProductGridItemFixture.variantOptions}
+          >
+            <ProductGridItem
+              copy={{
+                addToCart: AddToCartButtonFixture.copy,
+                ...ProductGridItemFixture.copy,
+              }}
+              info={ProductGridItemFixture.info}
+              url={ProductGridItemFixture.url}
+            />
+          </VariantSelectContextProvider>
+        </ProductDetailContextProvider>,
+      )
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/ProductGridItem/ProductGridItem.spec.js
+++ b/src/components/ProductGridItem/ProductGridItem.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import renderer from 'react-test-renderer';
+import ProductGridItem from './ProductGridItem';
+import ProductGridItemFixture from './ProductGridItem.fixture';
+
+configure({ adapter: new Adapter() });
+
+describe('<ProductGridItem />', () => {
+  it('should be defined', () => {
+    expect(ProductGridItem).toBeDefined();
+  });
+
+  it('renders base component correctly', () => {
+    const tree = renderer.create(<ProductGridItem />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -16,23 +16,25 @@ import styles from './ProductGridItemStorybook.module.css';
 
 # ProductGridItem
 
+Requires `AddToCartContextProvider`, `ProductDetailContextProvider` and `VariantSelectContextProvider`.
+
 <Preview>
   <Story name="Base component">
     <div className={styles.holder}>
       <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
         <ProductDetailContextProvider
-          product={ProductDetailHeaderFixture.product}
+          product={knobs.object('Product', ProductDetailHeaderFixture.product, 'Content')}
         >
           <VariantSelectContextProvider
-            variants={ProductGridItemFixture.variantOptions}
+            variants={knobs.object('Variant', ProductGridItemFixture.variantOptions, 'Content')}
           >
             <ProductGridItem
               copy={{
                 addToCart: AddToCartButtonFixture.copy,
                 ...ProductGridItemFixture.copy,
               }}
-              info={ProductGridItemFixture.info}
-              url={ProductGridItemFixture.url}
+              info={knobs.text('Info', ProductGridItemFixture.info, 'Content')}
+              url={knobs.text('URL', ProductGridItemFixture.url, 'Content')}
             />
           </VariantSelectContextProvider>
         </ProductDetailContextProvider>
@@ -40,6 +42,36 @@ import styles from './ProductGridItemStorybook.module.css';
     </div>
   </Story>
 </Preview>
+
+## Variations
+
+### Single variant
+
+<Preview>
+  <Story name="Single variant">
+    <div className={styles.holder}>
+      <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
+        <ProductDetailContextProvider
+          product={knobs.object('Product', ProductDetailHeaderFixture.product, 'Content')}
+        >
+          <VariantSelectContextProvider
+            variants={knobs.object('Variant', ProductGridItemFixture.variantOptionsOneItem, 'Content')}
+          >
+            <ProductGridItem
+              copy={{
+                addToCart: AddToCartButtonFixture.copy,
+                ...ProductGridItemFixture.copy,
+              }}
+              info={knobs.text('Info', ProductGridItemFixture.info, 'Content')}
+              url={knobs.text('URL', ProductGridItemFixture.url, 'Content')}
+            />
+          </VariantSelectContextProvider>
+        </ProductDetailContextProvider>
+      </AddToCartContextProvider>
+    </div>
+  </Story>
+</Preview>
+
 
 ## API
 

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -1,5 +1,13 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import * as knobs from '@storybook/addon-knobs';
+import {
+  AddToCartContextProvider,
+  ProductDetailContextProvider,
+  VariantSelectContextProvider,
+} from '~/contexts';
+import ProductDetailHeaderFixture from '~/components/ProductDetailHeader/ProductDetailHeader.fixture';
+import AddToCartButtonFixture from '~/components/AddToCartButton/AddToCartButton.fixture';
+import mockAddToCartButtonOnClick from '~/components/AddToCartButton/__mocks__/AddToCartButton.onClick';
 import ProductGridItem from './ProductGridItem';
 import ProductGridItemFixture from './ProductGridItem.fixture';
 
@@ -9,7 +17,22 @@ import ProductGridItemFixture from './ProductGridItem.fixture';
 
 <Preview>
   <Story name="Base component">
-    <ProductGridItem />
+    <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
+      <ProductDetailContextProvider
+        product={ProductDetailHeaderFixture.product}
+      >
+        <VariantSelectContextProvider
+          variants={ProductGridItemFixture.variantOptions}
+        >
+          <ProductGridItem
+            copy={{
+              addToCart: AddToCartButtonFixture.copy,
+              ...ProductGridItemFixture.copy,
+            }}
+          />
+        </VariantSelectContextProvider>
+      </ProductDetailContextProvider>
+    </AddToCartContextProvider>
   </Story>
 </Preview>
 

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -10,6 +10,7 @@ import AddToCartButtonFixture from '~/components/AddToCartButton/AddToCartButton
 import mockAddToCartButtonOnClick from '~/components/AddToCartButton/__mocks__/AddToCartButton.onClick';
 import ProductGridItem from './ProductGridItem';
 import ProductGridItemFixture from './ProductGridItem.fixture';
+import styles from './ProductGridItemStorybook.module.css';
 
 <Meta title="Components/ProductGridItem" component={ProductGridItem} />
 
@@ -17,24 +18,26 @@ import ProductGridItemFixture from './ProductGridItem.fixture';
 
 <Preview>
   <Story name="Base component">
-    <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
-      <ProductDetailContextProvider
-        product={ProductDetailHeaderFixture.product}
-      >
-        <VariantSelectContextProvider
-          variants={ProductGridItemFixture.variantOptions}
+    <div className={styles.holder}>
+      <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
+        <ProductDetailContextProvider
+          product={ProductDetailHeaderFixture.product}
         >
-          <ProductGridItem
-            copy={{
-              addToCart: AddToCartButtonFixture.copy,
-              ...ProductGridItemFixture.copy,
-            }}
-            info={ProductGridItemFixture.info}
-            url={ProductGridItemFixture.url}
-          />
-        </VariantSelectContextProvider>
-      </ProductDetailContextProvider>
-    </AddToCartContextProvider>
+          <VariantSelectContextProvider
+            variants={ProductGridItemFixture.variantOptions}
+          >
+            <ProductGridItem
+              copy={{
+                addToCart: AddToCartButtonFixture.copy,
+                ...ProductGridItemFixture.copy,
+              }}
+              info={ProductGridItemFixture.info}
+              url={ProductGridItemFixture.url}
+            />
+          </VariantSelectContextProvider>
+        </ProductDetailContextProvider>
+      </AddToCartContextProvider>
+    </div>
   </Story>
 </Preview>
 

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -29,6 +29,7 @@ import ProductGridItemFixture from './ProductGridItem.fixture';
               addToCart: AddToCartButtonFixture.copy,
               ...ProductGridItemFixture.copy,
             }}
+            info={ProductGridItemFixture.info}
             url={ProductGridItemFixture.url}
           />
         </VariantSelectContextProvider>

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import * as knobs from '@storybook/addon-knobs';
+import ProductGridItem from './ProductGridItem';
+// import ProductGridItem  from './ProductGridItem.fixture';
+
+<Meta title="Components/ProductGridItem" component={ProductGridItem} />
+
+# ProductGridItem
+
+<Preview>
+  <Story name="Base component">
+    <ProductGridItem />
+  </Story>
+</Preview>
+
+## API

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -29,6 +29,7 @@ import ProductGridItemFixture from './ProductGridItem.fixture';
               addToCart: AddToCartButtonFixture.copy,
               ...ProductGridItemFixture.copy,
             }}
+            url={ProductGridItemFixture.url}
           />
         </VariantSelectContextProvider>
       </ProductDetailContextProvider>

--- a/src/components/ProductGridItem/ProductGridItem.stories.mdx
+++ b/src/components/ProductGridItem/ProductGridItem.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import * as knobs from '@storybook/addon-knobs';
 import ProductGridItem from './ProductGridItem';
-// import ProductGridItem  from './ProductGridItem.fixture';
+import ProductGridItemFixture from './ProductGridItem.fixture';
 
 <Meta title="Components/ProductGridItem" component={ProductGridItem} />
 
@@ -14,3 +14,5 @@ import ProductGridItem from './ProductGridItem';
 </Preview>
 
 ## API
+
+<Props of={ProductGridItem} />

--- a/src/components/ProductGridItem/ProductGridItemStorybook.module.css
+++ b/src/components/ProductGridItem/ProductGridItemStorybook.module.css
@@ -1,0 +1,10 @@
+@import 'styles/index';
+
+.holder {
+  @media (--viewport-md) {
+    width: 50%;
+  }
+  @media (--viewport-lg) {
+    width: 460px;
+  }
+}

--- a/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
+++ b/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
@@ -128,35 +128,6 @@ exports[`<ProductGridItem /> renders base component correctly 1`] = `
           </span>
         </label>
       </li>
-      <li
-        className="radio"
-      >
-        <label
-          className="label"
-          htmlFor="option-ARD31"
-        >
-          <input
-            aria-checked={false}
-            checked={false}
-            className="input"
-            data-test-ref="PRODUCT_GRID_ITEM_VARIANT_SELECT"
-            id="option-ARD31"
-            name="sku"
-            onChange={[Function]}
-            tabIndex={0}
-            type="radio"
-            value="ARD31"
-          />
-          <span
-            className="pot dark"
-          />
-          <span
-            className="labelContent dark"
-          >
-            500 mL - Alternate action
-          </span>
-        </label>
-      </li>
       <div
         className="errorMessage"
       >

--- a/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
+++ b/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
@@ -1,0 +1,211 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProductGridItem /> renders base component correctly 1`] = `
+<div
+  className="base dark"
+>
+  <a
+    className="base left dark imageLink fadeEnter"
+    href="/p/"
+    target="_self"
+  >
+    <picture
+      className="base picture dark image"
+    >
+      <img />
+    </picture>
+  </a>
+  <h5
+    className="base mediumWeightFont xXSmall dark productName"
+  >
+    <a
+      className="base left dark productNameLink"
+      href="/p/"
+      target="_self"
+    >
+      Lorem ipsum dolor
+    </a>
+  </h5>
+  <div
+    className="infoVariantHolder"
+  >
+    <div
+      className="infoHolder"
+    >
+      <p
+        className="base dark info"
+      >
+        4 Sizes / From $ 26.45
+      </p>
+    </div>
+    <ul
+      className="base variants"
+    >
+      <li
+        className="radio"
+      >
+        <label
+          className="label"
+          htmlFor="option-ARD33"
+        >
+          <input
+            aria-checked={true}
+            checked={true}
+            className="input"
+            data-test-ref="PRODUCT_GRID_ITEM_VARIANT_SELECT"
+            id="option-ARD33"
+            name="sku"
+            onChange={[Function]}
+            tabIndex={0}
+            type="radio"
+            value="ARD33"
+          />
+          <span
+            className="pot dark"
+          />
+          <span
+            className="labelContent dark"
+          >
+            50 mL - In stock
+          </span>
+        </label>
+      </li>
+      <li
+        className="radio"
+      >
+        <label
+          className="label"
+          htmlFor="option-ARD32"
+        >
+          <input
+            aria-checked={false}
+            checked={false}
+            className="input"
+            data-test-ref="PRODUCT_GRID_ITEM_VARIANT_SELECT"
+            id="option-ARD32"
+            name="sku"
+            onChange={[Function]}
+            tabIndex={0}
+            type="radio"
+            value="ARD32"
+          />
+          <span
+            className="pot dark"
+          />
+          <span
+            className="labelContent dark"
+          >
+            100 mL - Not in stock
+          </span>
+        </label>
+      </li>
+      <li
+        className="radio"
+      >
+        <label
+          className="label"
+          htmlFor="option-ARD30"
+        >
+          <input
+            aria-checked={false}
+            checked={false}
+            className="input"
+            data-test-ref="PRODUCT_GRID_ITEM_VARIANT_SELECT"
+            id="option-ARD30"
+            name="sku"
+            onChange={[Function]}
+            tabIndex={0}
+            type="radio"
+            value="ARD30"
+          />
+          <span
+            className="pot dark"
+          />
+          <span
+            className="labelContent dark"
+          >
+            180 mL - In stock
+          </span>
+        </label>
+      </li>
+      <li
+        className="radio"
+      >
+        <label
+          className="label"
+          htmlFor="option-ARD31"
+        >
+          <input
+            aria-checked={false}
+            checked={false}
+            className="input"
+            data-test-ref="PRODUCT_GRID_ITEM_VARIANT_SELECT"
+            id="option-ARD31"
+            name="sku"
+            onChange={[Function]}
+            tabIndex={0}
+            type="radio"
+            value="ARD31"
+          />
+          <span
+            className="pot dark"
+          />
+          <span
+            className="labelContent dark"
+          >
+            500 mL - Alternate action
+          </span>
+        </label>
+      </li>
+      <div
+        className="errorMessage"
+      >
+        
+      </div>
+    </ul>
+  </div>
+  <button
+    className="base alternate blockStyle dark base fullWidth addToCartButton"
+    data-test-ref="PRODUCT_GRID_ITEM_ADD_TO_CART_CTA"
+    disabled={false}
+    onClick={[Function]}
+    title="Add to your cart — $26.45"
+    type="button"
+  >
+    <span
+      className="label"
+    >
+      <span>
+        Lorem ipsum dolor added to your cart
+      </span>
+      <span>
+        Add to your cart — $26.45
+      </span>
+    </span>
+  </button>
+  <dl
+    className="base dark hasBottomBorder definitionList"
+  >
+    <dt
+      className="term slideIn"
+    >
+      Lorem ipsum dolor
+    </dt>
+    <dd
+      className="description slideIn"
+    >
+      Lorem ipsum dolort, consectetur adipiscing elit.
+    </dd>
+    <dt
+      className="term slideIn"
+    >
+      Ut consectetur mi
+    </dt>
+    <dd
+      className="description slideIn"
+    >
+      Ut consectetur, vitae libero imperdiet id. 
+    </dd>
+  </dl>
+</div>
+`;

--- a/src/components/ProductGridItem/index.js
+++ b/src/components/ProductGridItem/index.js
@@ -1,0 +1,3 @@
+import ProductGridItem from './ProductGridItem';
+
+export default ProductGridItem;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -32,6 +32,7 @@ import Overlay from './Overlay';
 import Paragraph, { P, ParagraphSet } from './Paragraph';
 import Podium from './Podium';
 import ProductCommerce from './ProductCommerce';
+import ProductGridItem from './ProductGridItem';
 import ProductDetailHeader from './ProductDetailHeader';
 import Quote from './Quote';
 import RadioGroup from './RadioGroup';
@@ -83,6 +84,7 @@ export { Paragraph };
 export { ParagraphSet };
 export { Podium };
 export { ProductCommerce };
+export { ProductGridItem };
 export { ProductDetailHeader };
 export { Quote };
 export { RadioGroup };
@@ -135,6 +137,7 @@ export default {
   ParagraphSet,
   Podium,
   ProductCommerce,
+  ProductGridItem,
   ProductDetailHeader,
   Quote,
   RadioGroup,

--- a/src/styles/variables/color.css
+++ b/src/styles/variables/color.css
@@ -5,6 +5,7 @@
   --color-white: #fffef2;
   --color-white-dark: #f6f5e8;
   --color-white-darker: #e0dfd6;
+  --color-white-darker-2: #f0efe1;
   --color-white-rgba-20: rgba(255, 255, 255, 0.2);
   --color-white-rgba-60: rgba(255, 255, 255, 0.6);
   --color-black: #000;


### PR DESCRIPTION
#### Ticket
[AES-1695](https://aesoponline.atlassian.net/browse/AES-1695)

#### Description
Product item component that sits on category page of Web-UI
Figma designs: https://www.figma.com/file/nPp9PF2Y29yfBJ2RmNJHYk/Gifting-Experience-2020?node-id=181%3A0
Production site reference: https://www.aesop.com/au/c/skin/cleanse/

#### Dev notes
- Product image and title are linkable
- On desktop, radio and ATC button are hidden. Hovering over component will display them
- On mobile+tablet, radio and ATC button are displayed.
- If only one variant is available, `info` text is displayed instead of radio
- Keyboard tab focusing on desktop on radio and ATC button will trigger display

#### Screenshot
**Mobile**
![image](https://user-images.githubusercontent.com/31581926/90582455-1d2c8600-e211-11ea-8c2f-4753caf7948c.png)
**Tablet**
![image](https://user-images.githubusercontent.com/31581926/90705951-6fd07580-e2d7-11ea-8572-64209418e08c.png)
**Desktop without hover**
![image](https://user-images.githubusercontent.com/31581926/90582651-9fb54580-e211-11ea-8fca-7a2745599056.png)
**Desktop after hover**
![image](https://user-images.githubusercontent.com/31581926/90582675-afcd2500-e211-11ea-967f-c3d8d5dc3564.png)
