### PR TITLE
[Update][Feature/AES-1350]: Fix the margin for ReadMore desktop view

### DIFF
--- a/src/components/ReadMore/ReadMore.module.css
+++ b/src/components/ReadMore/ReadMore.module.css
@@ -11,8 +11,7 @@
     max-width: 1440px;
     flex-direction: row;
     justify-content: space-around;
-    margin-right: 60px;
-    margin-left: 60px;
+    margin: 0 auto;
   }
 }
 


### PR DESCRIPTION
 Fix the margin for ReadMore desktop view
<img width="1153" alt="Screen Shot 2020-08-21 at 1 46 31 pm" src="https://user-images.githubusercontent.com/51350376/90850339-c495ee00-e3b4-11ea-93da-3531b63c39f4.png">
<img width="880" alt="Screen Shot 2020-08-21 at 1 46 37 pm" src="https://user-images.githubusercontent.com/51350376/90850348-c9f33880-e3b4-11ea-8401-c269f6f591b8.png">
<img width="537" alt="Screen Shot 2020-08-21 at 1 46 43 pm" src="https://user-images.githubusercontent.com/51350376/90850352-cb246580-e3b4-11ea-966e-77fcdb8979d1.png">
