### PR TITLE
[Update][Feature/AES-1350]: Fix the margin for ReadMore desktop view

### DIFF
--- a/src/components/ReadMore/ReadMore.module.css
+++ b/src/components/ReadMore/ReadMore.module.css
@@ -11,7 +11,7 @@
     max-width: 1440px;
     flex-direction: row;
     justify-content: space-around;
-    margin: 0 auto;
+    margin: 0 20px;
   }
 }
 


### PR DESCRIPTION
Same padding as the nav bar in desktop view
<img width="1274" alt="Screen Shot 2020-08-25 at 11 00 32 am" src="https://user-images.githubusercontent.com/51350376/91110801-3d04f380-e6c2-11ea-99e7-09eec5ef6686.png">
