### PR TITLE
[UPDATE/product-grid]: button + infoHolder style

### DIFF
--- a/src/components/AddToCartButton/AddToCartButton.fixture.js
+++ b/src/components/AddToCartButton/AddToCartButton.fixture.js
@@ -2,7 +2,7 @@ export default {
   className: '',
   copy: {
     cartAction: 'Add to your cart',
-    updateNotification: 'added to your cart',
+    updateNotification: 'Added to your cart',
     outOfStock: {
       label: 'Out of Stock',
       title: 'Out of stock',

--- a/src/components/AddToCartButton/AddToCartButton.js
+++ b/src/components/AddToCartButton/AddToCartButton.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import {
-  useAddToCartContext,
-  useProductDetailContext,
-  useVariantSelectContext,
-} from 'contexts';
+import { useAddToCartContext, useVariantSelectContext } from 'contexts';
 import { HYPERLINK_STYLE_TYPES } from '~/constants';
 import Button from '~/components/Button';
 import Loading from '~/components/Loading';
@@ -21,12 +17,7 @@ const AddToCartButton = ({
   theme,
 }) => {
   const addToCart = useAddToCartContext();
-  const { productDetail } = useProductDetailContext();
   const { selectedVariant } = useVariantSelectContext();
-
-  if (!productDetail) return null;
-
-  const { productName } = productDetail;
   const { isInStock, price, sku, alternateAction } = selectedVariant;
 
   const classSet = cx(
@@ -75,7 +66,7 @@ const AddToCartButton = ({
 
   const { hasError, isLoading, isUpdateSuccessful } = addToCart;
   const cartActionLabel = `${copy.cartAction} — ${price}`;
-  const updateNotificationLabel = `${productName} ${copy.updateNotification}`;
+  const updateNotificationLabel = copy.updateNotification;
   const showUpdateSuccessMessage = !isLoading && isUpdateSuccessful;
 
   const labelClassName = cx(

--- a/src/components/AddToCartButton/AddToCartButton.stories.mdx
+++ b/src/components/AddToCartButton/AddToCartButton.stories.mdx
@@ -29,14 +29,12 @@ for an example.
       }
       return (
         <AddToCartContextProvider onClick={mockAddToCartButtonOnClick}>
-          <ProductDetailContextProvider product={productDetails}>
-            <VariantSelectContextProvider variants={ProductDetailHeaderFixture.product.variantOptions}>
-              <AddToCartButton
-                theme={theme}
-                copy={AddToCartButtonFixture.copy}
-              />
-            </VariantSelectContextProvider>
-          </ProductDetailContextProvider>
+          <VariantSelectContextProvider variants={ProductDetailHeaderFixture.product.variantOptions}>
+            <AddToCartButton
+              theme={theme}
+              copy={AddToCartButtonFixture.copy}
+            />
+          </VariantSelectContextProvider>
         </AddToCartContextProvider>
       )
     })()}

--- a/src/components/AddToCartButton/__snapshots__/AddToCartButton.spec.js.snap
+++ b/src/components/AddToCartButton/__snapshots__/AddToCartButton.spec.js.snap
@@ -13,7 +13,7 @@ exports[`<AddToCartButton /> renders base component correctly 1`] = `
     className="label"
   >
     <span>
-      Lorem ipsum dolor added to your cart
+      Added to your cart
     </span>
     <span>
       Add to your cart — $26.45

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -90,7 +90,7 @@
 
 .infoHolder {
   @media (--viewport-sm-md-only) {
-    margin-bottom: var(--layout-sm-spacing);
+    margin-bottom: 24px;
     opacity: 1;
   }
   @media (--viewport-lg) {
@@ -99,6 +99,7 @@
 }
 
 .info {
+  margin-bottom: 0;
   color: var(--color-grey-30);
   font-size: rem(14px);
   text-align: center;
@@ -122,6 +123,7 @@
 }
 
 .addToCartButton {
+  max-width: 100%;
   @media (--viewport-lg) {
     position: absolute;
     right: 0;

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -134,6 +134,7 @@
     right: 0;
     bottom: 0;
     left: 0;
+    max-width: 100%;
     opacity: 0;
 
     &:focus {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -1,6 +1,7 @@
 @import 'styles/index';
 
 .base {
+  width: 100%;
   transition: background-color 300ms var(--easing-ease-out-cubic);
 
   @media (--viewport-sm-only) {

--- a/src/components/ProductGridItem/ProductGridItem.module.css
+++ b/src/components/ProductGridItem/ProductGridItem.module.css
@@ -72,6 +72,10 @@
   margin-top: 0;
   margin-bottom: 7px;
   text-align: center;
+
+  a {
+    font-family: inherit;
+  }
 }
 
 .productNameLink {

--- a/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
+++ b/src/components/ProductGridItem/__snapshots__/ProductGridItem.spec.js.snap
@@ -147,7 +147,7 @@ exports[`<ProductGridItem /> renders base component correctly 1`] = `
       className="label"
     >
       <span>
-        Lorem ipsum dolor added to your cart
+        Added to your cart
       </span>
       <span>
         Add to your cart — $26.45


### PR DESCRIPTION
- Adding styling tweaks to `ProductGridItem`
- Removed 'product name' and 'product context' dependency on `AddToCartButton` component

![image](https://user-images.githubusercontent.com/31581926/91113848-d97ec400-e6c9-11ea-8d66-9e462aa93959.png)
