### PR TITLE
Raise pr on tag push

### DIFF
--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -29,10 +29,24 @@ jobs:
       - name: Update Gel
         run: npm install --save github:aesop/aesop-gel#$GEL_VERSION
 
+      - name: Commit and push update
+        run: |
+          git config user.name "Jenkins Aesop"
+          git config user.email ""
+          git add ./package*
+          git checkout -b $BRANCH_NAME
+          git commit -m "chore(update-gel): update Aesop Gel to ${GEL_VERSION}"
+          git push --set-upstream origin $BRANCH_NAME
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-            token: ${{ secrets.X_GITHUB_TOKEN }}
-            commit-message: Update Gel to ${{ env.GEL_VERSION }}
-            title: Update Gel to ${{ env.GEL_VERSION }}
-            branch: update-gel-to-${{ env.GEL_VERSION }}
+        run: |
+          curl \
+          -u "jenkins-aesop:${TOKEN}" \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/aesop/aesop-web-ui/pulls \
+          -d "{\"title\":\"Update Aesop Gel to ${GEL_VERSION}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"develop\"}"
+        env:
+          TOKEN: ${{ secrets.X_GITHUB_TOKEN }}
+          VERSION: ${{ env.GEL_VERSION }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -17,17 +17,22 @@ jobs:
           ref: 'develop'
           token: ${{ secrets.X_GITHUB_TOKEN }}
 
+      - name: Create variables
+        run: |
+          echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
+          echo "::set-env name=BRANCH_NAME::update-Gel-to-${GEL_VERSION}"
+
       - name: npm install
-        run: npm install --save github:aesop/aesop-gel#$GITHUB_REF
+        run: npm install --save github:aesop/aesop-gel#$GEL_VERSION
 
       - name: Commit and push update
         run: |
           git config user.name "Gel Updater"
           git config user.email ""
           git add ./package*
-          git checkout -b update-Gel-to-$GITHUB_REF
-          git commit -m "chore(update-gel): update Aesop Gel to ${GITHUB_REF}"
-          git push
+          git checkout -b $BRANCH_NAME
+          git commit -m "chore(update-gel): update Aesop Gel to ${GEL_VERSION}"
+          git push --set-upstream origin $BRANCH_NAME
 
       - name: Create PR
         run: |
@@ -35,4 +40,4 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/aesop/aesop-web-ui/pulls \
-          -d '{"title":"update Aesop Gel to ${GITHUB_REF}","head":"update-Gel-to-${GITHUB_REF}","base":"develop"}'
+          -d '{"title":"Update Aesop Gel to ${GITHUB_REF}","head":"${BRANCH_NAME}","base":"develop"}'

--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Create variables
         run: |
           echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
-          echo "::set-env name=BRANCH_NAME::update-Gel-to-${GEL_VERSION}"
+          echo "::set-env name=BRANCH_NAME::update-Gel-to-${GITHUB_REF#refs/*/}"
 
       - name: npm install
         run: npm install --save github:aesop/aesop-gel#$GEL_VERSION
@@ -40,4 +40,4 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/aesop/aesop-web-ui/pulls \
-          -d '{"title":"Update Aesop Gel to ${GITHUB_REF}","head":"${BRANCH_NAME}","base":"develop"}'
+          -d '{"title":"Update Aesop Gel to ${GEL_VERSION}","head":"${BRANCH_NAME}","base":"develop"}'

--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -9,6 +9,10 @@ jobs:
     name: Update Web UI
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+
       - name: Checkout Web UI
         uses: actions/checkout@v2
         with:
@@ -22,22 +26,13 @@ jobs:
           echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
           echo "::set-env name=BRANCH_NAME::update-Gel-to-${GITHUB_REF#refs/*/}"
 
-      - name: npm install
+      - name: Update Gel
         run: npm install --save github:aesop/aesop-gel#$GEL_VERSION
 
-      - name: Commit and push update
-        run: |
-          git config user.name "Gel Updater"
-          git config user.email ""
-          git add ./package*
-          git checkout -b $BRANCH_NAME
-          git commit -m "chore(update-gel): update Aesop Gel to ${GEL_VERSION}"
-          git push --set-upstream origin $BRANCH_NAME
-
-      - name: Create PR
-        run: |
-          curl \
-          -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/aesop/aesop-web-ui/pulls \
-          -d '{"title":"Update Aesop Gel to ${GEL_VERSION}","head":"${BRANCH_NAME}","base":"develop"}'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+            token: ${{ secrets.X_GITHUB_TOKEN }}
+            commit-message: Update Gel to ${{ env.GEL_VERSION }}
+            title: Update Gel to ${{ env.GEL_VERSION }}
+            branch: update-gel-to-${{ env.GEL_VERSION }}

--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -1,0 +1,38 @@
+name: Update Web UI
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  update_web_ui:
+    name: Update Web UI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Web UI
+        uses: actions/checkout@v2
+        with:
+          repository: 'aesop/aesop-web-ui'
+          fetch-depth: 1
+          ref: 'develop'
+          token: ${{ secrets.X_GITHUB_TOKEN }}
+
+      - name: npm install
+        run: npm install --save github:aesop/aesop-gel#$GITHUB_REF
+
+      - name: Commit and push update
+        run: |
+          git config user.name "Gel Updater"
+          git config user.email ""
+          git add ./package*
+          git checkout -b update-Gel-to-$GITHUB_REF
+          git commit -m "chore(update-gel): update Aesop Gel to ${GITHUB_REF}"
+          git push
+
+      - name: Create PR
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/aesop/aesop-web-ui/pulls \
+          -d '{"title":"update Aesop Gel to ${GITHUB_REF}","head":"update-Gel-to-${GITHUB_REF}","base":"develop"}'

--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           node-version: '10.x'
 
+      - name: Create variables
+        run: |
+          echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
+
       - name: Checkout Web UI
         uses: actions/checkout@v2
         with:
@@ -21,32 +25,17 @@ jobs:
           ref: 'develop'
           token: ${{ secrets.X_GITHUB_TOKEN }}
 
-      - name: Create variables
-        run: |
-          echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
-          echo "::set-env name=BRANCH_NAME::update-Gel-to-${GITHUB_REF#refs/*/}"
+      - name: Checkout private tools
+        uses: actions/checkout@v2
+        with:
+          repository: aesop/aesop-github-action
+          token: ${{ secrets.X_GITHUB_TOKEN }}
+          path: actions
 
       - name: Update Gel
-        run: npm install --save github:aesop/aesop-gel#$GEL_VERSION
-
-      - name: Commit and push update
-        run: |
-          git config user.name "Jenkins Aesop"
-          git config user.email ""
-          git add ./package*
-          git checkout -b $BRANCH_NAME
-          git commit -m "chore(update-gel): update Aesop Gel to ${GEL_VERSION}"
-          git push --set-upstream origin $BRANCH_NAME
-
-      - name: Create Pull Request
-        run: |
-          curl \
-          -u "jenkins-aesop:${TOKEN}" \
-          -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/aesop/aesop-web-ui/pulls \
-          -d "{\"title\":\"Update Aesop Gel to ${GEL_VERSION}\",\"head\":\"${BRANCH_NAME}\",\"base\":\"develop\"}"
-        env:
+        uses: ./actions/create-pr
+        with:
           TOKEN: ${{ secrets.X_GITHUB_TOKEN }}
           VERSION: ${{ env.GEL_VERSION }}
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          CREATE_IN: 'aesop-web-ui'
+          BASE_BRANCH: 'develop'


### PR DESCRIPTION
### What
These changes will update the version of Aesop Gel in Aesop Web UI every time a new version (tag) of Gel is published. The update is done on a separate branch and PR is created to merge it to develop.

### Why
Very often multiple PR on Aesop Web UI are updating the version of Gel as part of their changes. This can cause conflicts at the time of merge and may require rebasing to drop changes to `package.json` and `package-lock.json`.

### How
1. The workflow runs for every tag push
2. It checks out Aesop Web UI
3. It runs a custom [GitHub action](https://github.com/aesop/aesop-github-action/tree/create-pr-action/create-pr)

#### Example:

[PR 1](https://github.com/aesop/aesop-web-ui/pull/3162): this was created on tag push. Then closed when another tag was pushed.
[PR 2](https://github.com/aesop/aesop-web-ui/pull/3163) This was created upon push of a new tag. It closed the above unmerged PR.

