### PR TITLE
[Feature][AES-708] Adjust margin for Double Media Component

### DIFF
--- a/src/components/DoubleMedia/components/MediaBlock/MediaBlock.module.css
+++ b/src/components/DoubleMedia/components/MediaBlock/MediaBlock.module.css
@@ -9,7 +9,9 @@
 }
 
 .figure {
-  margin-bottom: calc(var(--layout-sm-spacing) * 2);
+  &:first-of-type {
+    margin-bottom: 45px;
+  }
 
   @media (--viewport-md) {
     flex: 0 0 calc(50% - var(--layout-md-spacing) / 4);


### PR DESCRIPTION
This PR adjusts the bottom margin for the Double Media Block, as requested in https://aesoponline.atlassian.net/browse/AES-708