### PR TITLE
Use product sku as name for radio groups in ProductCommerce and ProductGridItem

### DIFF
--- a/src/components/ProductCommerce/ProductCommerce.js
+++ b/src/components/ProductCommerce/ProductCommerce.js
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { HEADING, HYPERLINK_STYLE_TYPES } from '~/constants';
-import { useVariantSelectContext } from '~/contexts';
+import { useProductDetailContext, useVariantSelectContext } from '~/contexts';
 import { useImageTransition } from '~/customHooks';
 import { getVariantRadioOptions } from '~/utils/product';
 import AddToCartButton from '~/components/AddToCartButton';
@@ -34,6 +34,7 @@ const ProductCommerce = ({
     variants,
   } = useVariantSelectContext();
 
+  const { sku } = useProductDetailContext();
   const [currentImage, isImageActive] = useImageTransition(
     selectedVariant?.image,
     imageRef,
@@ -45,7 +46,7 @@ const ProductCommerce = ({
 
   const variantRadioOptions = getVariantRadioOptions(variants);
   const classSet = cx(styles.base, className);
-  const RADIO_GROUP_NAME = 'sku';
+  const RADIO_GROUP_NAME = sku;
   const RADIO_GROUP_DATA_TEST_REF = 'PRODUCT_COMMERCE_VARIANT_SELECT';
 
   return (
@@ -81,7 +82,6 @@ const ProductCommerce = ({
           >
             {copy?.size}
           </Heading>
-
           <RadioGroup
             className={styles.variants}
             dataTestRef={RADIO_GROUP_DATA_TEST_REF}

--- a/src/components/ProductGridItem/ProductGridItem.js
+++ b/src/components/ProductGridItem/ProductGridItem.js
@@ -34,7 +34,7 @@ const ProductGridItem = ({ className, copy, id, info, theme, url }) => {
     imageRef,
   );
 
-  const { productDetail } = useProductDetailContext();
+  const { productDetail, sku } = useProductDetailContext();
 
   if (!productDetail) return null;
 
@@ -46,7 +46,7 @@ const ProductGridItem = ({ className, copy, id, info, theme, url }) => {
     [styles.hasOneVariant]: hasOneVariant,
   });
 
-  const RADIO_GROUP_NAME = 'sku';
+  const RADIO_GROUP_NAME = sku;
   const RADIO_GROUP_DATA_TEST_REF = 'PRODUCT_GRID_ITEM_VARIANT_SELECT';
 
   return (


### PR DESCRIPTION
This is a small PR to fix a bug with multiple ProductGridItems or ProductCommerce components on a single page where they would share a `name` attribute and thus only one could properly be 'checked'