### PR TITLE
Adding AddToCartCopy to HorizontalProductDisplayAccordion

### DIFF
--- a/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.js
+++ b/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.js
@@ -11,7 +11,7 @@ import { ascertainIsSmallOnlyViewport } from '~/utils/viewports';
 import useWindowHasResized from '~/customHooks/useWindowHasResized';
 import debounce from 'lodash/debounce';
 
-const HorizontalProductDisplayAccordion = ({ id, products }) => {
+const HorizontalProductDisplayAccordion = ({ id, products, addToCartCopy }) => {
   const [accordionProducts, toggleAccordionProducts] = useState(products);
   const [accordionActive, toggleAccordionActiveState] = useState(false);
   let isMobile = ascertainIsSmallOnlyViewport();
@@ -81,7 +81,7 @@ const HorizontalProductDisplayAccordion = ({ id, products }) => {
     return function callback() {
       window.removeEventListener('resize', resetAccordionOnResize);
     };
-  });
+  }, []);
 
   useWindowHasResized();
 
@@ -106,6 +106,7 @@ const HorizontalProductDisplayAccordion = ({ id, products }) => {
               variants={product.openState.product.variants}
             >
               <AccordionProduct
+                addToCartCopy={addToCartCopy}
                 index={productIndex}
                 resetAccordion={resetAccordion}
                 toggleAccordion={toggleAccordion}
@@ -122,17 +123,17 @@ const HorizontalProductDisplayAccordion = ({ id, products }) => {
 HorizontalProductDisplayAccordion.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string,
+  addToCartCopy: PropTypes.shape({
+    cartAction: PropTypes.string,
+    updateNotification: PropTypes.string,
+    outOfStock: PropTypes.shape({
+      label: PropTypes.string,
+      title: PropTypes.string,
+    }),
+  }),
   openIndex: PropTypes.string,
   products: PropTypes.arrayOf(
     PropTypes.shape({
-      addToCart: PropTypes.shape({
-        cartAction: PropTypes.string,
-        updateNotification: PropTypes.string,
-        outOfStock: PropTypes.shape({
-          label: PropTypes.string,
-          title: PropTypes.string,
-        }),
-      }),
       closedState: PropTypes.shape({
         background: PropTypes.oneOf(['Colour', 'Image', 'Video']),
         backgroundColour: PropTypes.string,
@@ -181,15 +182,15 @@ HorizontalProductDisplayAccordion.defaultProps = {
   className: undefined,
   id: undefined,
   openIndex: null,
-  products: {
-    addToCart: {
-      cartAction: undefined,
-      updateNotification: undefined,
-      outOfStock: {
-        label: undefined,
-        title: undefined,
-      },
+  addToCartCopy: {
+    cartAction: undefined,
+    updateNotification: undefined,
+    outOfStock: {
+      label: undefined,
+      title: undefined,
     },
+  },
+  products: {
     closedState: {
       background: 'Image',
       backgroundColour: undefined,

--- a/src/components/HorizontalProductDisplayAccordion/components/AccordionProduct/AccordionProduct.js
+++ b/src/components/HorizontalProductDisplayAccordion/components/AccordionProduct/AccordionProduct.js
@@ -10,7 +10,7 @@ import Image from '~/components/Image';
 import styles from './AccordionProduct.module.css';
 
 const AccordionProduct = ({
-  addToCart,
+  addToCartCopy,
   closedState,
   isCompressed,
   isExpanded,
@@ -20,6 +20,7 @@ const AccordionProduct = ({
   resetAccordion,
   toggleAccordion,
 }) => {
+  console.log('AccordionProduct', addToCartCopy);
   return (
     <div
       className={cx(
@@ -131,7 +132,7 @@ const AccordionProduct = ({
               {openState?.copy}
             </div>
             <div className={cx(styles.buttonGroup)}>
-              <AddToCartButton copy={addToCart} theme={openState.theme} />
+              <AddToCartButton copy={addToCartCopy} theme={openState.theme} />
               {openState?.cta && (
                 <Hyperlink
                   className={styles.cta}
@@ -157,7 +158,7 @@ const AccordionProduct = ({
 };
 
 AccordionProduct.propTypes = {
-  addToCart: PropTypes.shape({
+  addToCartCopy: PropTypes.shape({
     cartAction: PropTypes.string,
     updateNotification: PropTypes.string,
     outOfStock: PropTypes.shape({
@@ -204,7 +205,7 @@ AccordionProduct.propTypes = {
 };
 
 AccordionProduct.defaultProps = {
-  addToCart: {
+  addToCartCopy: {
     cartAction: undefined,
     updateNotification: undefined,
     outOfStock: {

--- a/src/components/HorizontalProductDisplayAccordion/components/AccordionProduct/AccordionProduct.js
+++ b/src/components/HorizontalProductDisplayAccordion/components/AccordionProduct/AccordionProduct.js
@@ -20,7 +20,6 @@ const AccordionProduct = ({
   resetAccordion,
   toggleAccordion,
 }) => {
-  console.log('AccordionProduct', addToCartCopy);
   return (
     <div
       className={cx(


### PR DESCRIPTION
Because of the way this component manages it's `product` state internally we can't update the `products` array after it's been sent to the component. To remedy this I've passed the `AddToCartCopy` as a separate prop that then gets passed into the add to cart button. 

Alternatively this component should have a useEffect that recalculates the `accordionProducts` state each time `props.products` changes.