### PR TITLE
Horizontal Accordion: update fixtures to fix tests

### DIFF
--- a/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.fixture.js
+++ b/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.fixture.js
@@ -1,14 +1,14 @@
 export default {
+  addToCartCopy: {
+    cartAction: 'Add to your cart',
+    updateNotification: 'added to your cart',
+    outOfStock: {
+      label: 'Out of Stock',
+      title: 'Out of stock',
+    },
+  },
   products: [
     {
-      addToCart: {
-        cartAction: 'Add to your cart',
-        updateNotification: 'added to your cart',
-        outOfStock: {
-          label: 'Out of Stock',
-          title: 'Out of stock',
-        },
-      },
       closedState: {
         background: 'Image',
         backgroundColor: '#9DB5AC',
@@ -91,14 +91,6 @@ export default {
       },
     },
     {
-      addToCart: {
-        cartAction: 'Add to your cart',
-        updateNotification: 'added to your cart',
-        outOfStock: {
-          label: 'Out of Stock',
-          title: 'Out of stock',
-        },
-      },
       closedState: {
         background: 'Video',
         backgroundColor: '#9DB5AC',
@@ -204,14 +196,6 @@ export default {
       },
     },
     {
-      addToCart: {
-        cartAction: 'Add to your cart',
-        updateNotification: 'added to your cart',
-        outOfStock: {
-          label: 'Out of Stock',
-          title: 'Out of stock',
-        },
-      },
       closedState: {
         background: 'Image',
         backgroundColor: '#BAC7B2',

--- a/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.spec.js
+++ b/src/components/HorizontalProductDisplayAccordion/HorizontalProductDisplayAccordion.spec.js
@@ -16,6 +16,7 @@ describe('<HorizontalProductDisplayAccordion />', () => {
     const tree = renderer
       .create(
         <HorizontalProductDisplayAccordion
+          addToCartCopy={HorizontalProductDisplayAccordionFixture.addToCartCopy}
           products={HorizontalProductDisplayAccordionFixture.products}
         />,
       )


### PR DESCRIPTION
Updating the fixtures to match the new prop types from https://github.com/aesop/aesop-gel/pull/186