### PR TITLE
chore: remove linting on push

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,4 +1,3 @@
 "hooks": {
-  "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-  "pre-push": "npm run lint && npm run pretty"
+  "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
 }


### PR DESCRIPTION
PR [183](https://github.com/aesop/aesop-gel/pull/183) eliminates the need for running linting locally on push.