### PR TITLE
fix: enable video autoplay

### DIFF
--- a/src/components/DoubleMedia/components/MediaBlock/MediaBlock.js
+++ b/src/components/DoubleMedia/components/MediaBlock/MediaBlock.js
@@ -27,7 +27,7 @@ const MediaBlock = ({
       <Video
         fallbackImage={fallbackImage}
         hasAllowAudio={false}
-        hasAutoplay={isScrollBasedVideo ? false : true}
+        hasAutoplay={true}
         hasControls={false}
         hasLoop={true}
         hasPlayInFullScreen={false}


### PR DESCRIPTION
Enabling autoplay as videos were not showing up without it.