### PR TITLE
[Feature][AES-1511] Product description box width adjustment

### DIFF
--- a/src/components/DefinitionListWithProductExtract/__snapshots__/DefinitionListWithProductExtract.spec.js.snap
+++ b/src/components/DefinitionListWithProductExtract/__snapshots__/DefinitionListWithProductExtract.spec.js.snap
@@ -7,7 +7,9 @@ exports[`<DefinitionListWithProductExtract /> renders base component correctly 1
   <div
     className="flexContainer delayAnimation slideIn"
   >
-    <div>
+    <div
+      className="productDescription"
+    >
       <h4
         className="base xXSmall dark heading delayAnimation slideIn"
       >

--- a/src/components/ProductExtract/ProductExtract.js
+++ b/src/components/ProductExtract/ProductExtract.js
@@ -45,6 +45,8 @@ const ProductExtract = forwardRef(function ProductExtractRef(
     className,
   );
 
+  const productDescriptionClassSet = cx(styles.productDescription);
+
   const productNameClassSet = cx(
     styles.productName,
     styles.delayAnimation,
@@ -83,7 +85,7 @@ const ProductExtract = forwardRef(function ProductExtractRef(
         )}
       >
         <div className={flexClassSet}>
-          <div>
+          <div className={productDescriptionClassSet}>
             <Heading
               className={headingClassSet}
               level={HEADING.LEVEL.FOUR}

--- a/src/components/ProductExtract/ProductExtract.module.css
+++ b/src/components/ProductExtract/ProductExtract.module.css
@@ -127,3 +127,7 @@
 .hasBottomBorder {
   border-bottom: 1px solid var(--color-grey-65);
 }
+
+.productDescription {
+  width: 70%;
+}

--- a/src/components/ProductExtract/__snapshots__/ProductExtract.spec.js.snap
+++ b/src/components/ProductExtract/__snapshots__/ProductExtract.spec.js.snap
@@ -14,7 +14,9 @@ exports[`<ProductExtract /> renders base component correctly 1`] = `
     <div
       className="flexContainer delayAnimation slideIn"
     >
-      <div>
+      <div
+        className="productDescription"
+      >
         <h4
           className="base xXSmall dark heading delayAnimation slideIn"
         >


### PR DESCRIPTION
Testing different screen sizes showed that the text may sometimes come too close to the image. Thus, set the product description container width to 70% to account for this.

Also updated snapshots.