### PR TITLE
fix(text over full width asset): fix space after image

### DIFF
--- a/src/components/TextOverFullWidthAsset/TextOverFullWidthAsset.module.css
+++ b/src/components/TextOverFullWidthAsset/TextOverFullWidthAsset.module.css
@@ -12,6 +12,7 @@
 
   img {
     object-fit: cover;
+    vertical-align: middle;
 
     @media (--viewport-sm-only) {
       height: 80vh;


### PR DESCRIPTION
Currently the image tag has a tiny bit of space after it. This change removes that.

[Stack overflow question about this](https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image).