### PR TITLE
fix: correct element ordering to eliminate flicker

### DIFF
--- a/src/components/Podium/Podium.js
+++ b/src/components/Podium/Podium.js
@@ -42,12 +42,12 @@ const Podium = forwardRef(function PodiumRef(
   const style = backgroundColor ? { backgroundColor } : undefined;
 
   return (
-    <Transition
-      isActive={isActive}
-      isActiveOnMount={isActiveOnMount}
-      type={transition}
-    >
-      <ThemeContextProvider theme={theme}>
+    <ThemeContextProvider theme={theme}>
+      <Transition
+        isActive={isActive}
+        isActiveOnMount={isActiveOnMount}
+        type={transition}
+      >
         <section
           className={classSet}
           data-test-ref={dataTestRef}
@@ -56,8 +56,8 @@ const Podium = forwardRef(function PodiumRef(
         >
           {children}
         </section>
-      </ThemeContextProvider>
-    </Transition>
+      </Transition>
+    </ThemeContextProvider>
   );
 });
 


### PR DESCRIPTION
This PR is a fit to eliminate the fade transition flicker due to incorrect component ordering