### PR TITLE
chore(deps): update uuid to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5392,6 +5392,14 @@
             "log-symbols": "^2.1.0",
             "loglevelnext": "^1.0.1",
             "uuid": "^3.1.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
           }
         }
       }
@@ -28223,6 +28231,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -31094,6 +31108,12 @@
           "requires": {
             "pify": "^3.0.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -32248,9 +32268,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -33223,6 +33243,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-collapse": "5.0.1",
     "react-dom": "^16.8.0",
     "react-slick": "0.25.2",
-    "uuid": "3.4.0",
+    "uuid": "8.3.1",
     "wavesurfer.js": "3.3.3"
   },
   "dependencies": {
@@ -66,7 +66,7 @@
     "react-dom": "^16.8.0",
     "react-slick": "0.25.2",
     "react-transition-group-npm": "npm:react-transition-group@^4.4.1",
-    "uuid": "3.4.0",
+    "uuid": "8.3.1",
     "video-scroller": "^1.1.1",
     "wavesurfer.js": "3.3.3"
   },

--- a/src/components/FlyinPanel/FlyinPanel.js
+++ b/src/components/FlyinPanel/FlyinPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import { useEscapeKeyListener } from '~/customHooks/useEscapeKeyListener';
 import { useOverflowHidden } from '~/customHooks/useOverflowHidden';
 import Button from '~/components/Button';

--- a/src/components/FlyinPanel/FlyinPanel.spec.js
+++ b/src/components/FlyinPanel/FlyinPanel.spec.js
@@ -6,9 +6,11 @@ import FlyinPanel from './FlyinPanel';
 
 configure({ adapter: new Adapter() });
 
-jest.mock('uuid/v4', () => {
+jest.mock('uuid', () => {
   let value = 0;
-  return () => value++;
+  return {
+    v4: () => value++,
+  };
 });
 
 const mockFn = jest.fn();

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import find from 'lodash/find';
 import svgs from './Icon.svgs';
 import { generateSvgBlueprint } from './Icon.utils';

--- a/src/components/Icon/Icon.spec.js
+++ b/src/components/Icon/Icon.spec.js
@@ -6,9 +6,11 @@ import Icon from './Icon';
 
 configure({ adapter: new Adapter() });
 
-jest.mock('uuid/v4', () => {
+jest.mock('uuid', () => {
   let value = 0;
-  return () => value++;
+  return {
+    v4: () => value++,
+  };
 });
 
 describe('<Icon />', () => {


### PR DESCRIPTION
## Background 
From version 5 [Webpack will no longer automatically add browser polyfills for core node modules](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed). 

### Current Gel
The current version of uuid used in Gel relied on those polyfills from web ui. This is also reflected in the output of the build command.
![image](https://user-images.githubusercontent.com/33766083/99006526-b6f89a80-2596-11eb-94c1-52c56caa358c.png)


### PR changes
Update uuid package to the latest version which can run on node/browser without relying on external polyfills. This is in preparation for Web UI updating Webpack version. The output of the build command after the version update no longer shows the warning seen above.

![image](https://user-images.githubusercontent.com/33766083/99006244-40f43380-2596-11eb-8dfa-0a862c04bc9c.png)

I updated locations where the library was used and checked that it still works.