### PR TITLE
Refactor/remove window references

### DIFF
--- a/src/components/FullWidthHeroScroll/FullWidthHeroScroll.js
+++ b/src/components/FullWidthHeroScroll/FullWidthHeroScroll.js
@@ -7,6 +7,7 @@ import Hyperlink from '~/components/Hyperlink';
 import Icon from '~/components/Icon';
 import BackgroundElement from './components/BackgroundElement';
 import FullscreenSection from './components/FullscreenSection';
+import { isInBrowser } from '~/utils/environment';
 import styles from './FullWidthHeroScroll.module.css';
 
 const FullWidthHeroScroll = ({
@@ -45,11 +46,13 @@ const FullWidthHeroScroll = ({
   });
 
   const handleScrollDown = () => {
-    window.scroll({
-      top: window.innerHeight - offset,
-      left: 0,
-      behavior: 'smooth',
-    });
+    if (isInBrowser()) {
+      window.scroll({
+        top: window.innerHeight - offset,
+        left: 0,
+        behavior: 'smooth',
+      });
+    }
   };
 
   const classSet = cx(styles.base, styles[theme], {

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -88,7 +88,7 @@ export const Video = forwardRef(function VideoRef(
     setIsPlaying(false);
     setHasActiveVideo(false);
 
-    window.setTimeout(() => {
+    setTimeout(() => {
       videoRef.current.currentTime = 0;
       videoRef.current.load();
       setProgress(0);

--- a/src/components/Video/components/Controls/Controls.js
+++ b/src/components/Video/components/Controls/Controls.js
@@ -7,6 +7,7 @@ import { ascertainIsSmallOrMediumOnlyViewport } from '~/utils/viewports';
 import Button from '~/components/Button';
 import Icon from '~/components/Icon';
 import Transition from '~/components/Transition';
+import { isInBrowser } from '~/utils/environment';
 import styles from './Controls.module.css';
 
 const Controls = ({
@@ -33,10 +34,11 @@ const Controls = ({
   });
 
   const eventTimeout = useRef(null);
-  const windowIsDefined = typeof window !== 'undefined';
+  const windowIsDefined = isInBrowser();
   const TIMEOUT = 3000;
 
   useEffect(() => {
+    // TODO: wrapping calls inside a useEffect in window presence checks may be redundant
     if (windowIsDefined) {
       window.clearTimeout(eventTimeout.current);
     }

--- a/src/customHooks/useImageTransition.js
+++ b/src/customHooks/useImageTransition.js
@@ -16,7 +16,7 @@ const useImageTransition = (image, ref, duration = 600, attributes = {}) => {
     };
 
     if (windowIsDefined && ref.current) {
-      timeout.current = window.setTimeout(() => {
+      timeout.current = setTimeout(() => {
         setCurrentImage({ ...image, ...attributes });
 
         if (currentRef.complete) {
@@ -29,7 +29,7 @@ const useImageTransition = (image, ref, duration = 600, attributes = {}) => {
 
     return function cleanup() {
       if (windowIsDefined) {
-        window.clearTimeout(timeout.current);
+        clearTimeout(timeout.current);
       }
 
       currentRef.removeEventListener('load', handleOnImageLoad);

--- a/src/customHooks/useOnScreen.js
+++ b/src/customHooks/useOnScreen.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 
+import { isInBrowser } from '~/utils/environment';
+
 const hasIntersectionObserver =
-  'IntersectionObserver' in window ||
+  (isInBrowser() && 'IntersectionObserver' in window) ||
   'IntersectionObserverEntry' in window ||
   ('IntersectionObserverEntry' in window &&
     'intersectionRatio' in window.IntersectionObserverEntry.prototype);

--- a/src/customHooks/useScript.js
+++ b/src/customHooks/useScript.js
@@ -1,7 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-
-const isBrowser =
-  typeof window !== 'undefined' && typeof window.document !== 'undefined';
+import { isInBrowser } from '~/utils/environment';
 
 const useScript = ({
   src,
@@ -19,7 +17,7 @@ const useScript = ({
   count.current += 1;
 
   useEffect(() => {
-    if (!isBrowser) return;
+    if (!isInBrowser()) return;
 
     if (checkForExisting) {
       const existing = document.querySelectorAll(`script[src="${src}"]`);

--- a/src/customHooks/useWindowHasResized.js
+++ b/src/customHooks/useWindowHasResized.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import debounce from 'lodash/debounce';
 
-const windowIsDefined = typeof window !== 'undefined';
+import { isInBrowser } from '~/utils/environment';
 
 export const useWindowHasResized = callback => {
   const [windowSize, setWindowSize] = useState({
@@ -12,19 +12,19 @@ export const useWindowHasResized = callback => {
   useEffect(() => {
     const handleResize = debounce(() => {
       setWindowSize({
-        height: windowIsDefined ? window.innerHeight : 0,
-        width: windowIsDefined ? window.innerWidth : 0,
+        height: isInBrowser() ? window.innerHeight : 0,
+        width: isInBrowser() ? window.innerWidth : 0,
       });
 
       if (callback) callback();
     }, 200);
 
-    if (windowIsDefined) {
+    if (isInBrowser()) {
       window.addEventListener('resize', handleResize);
     }
 
     return function cleanUp() {
-      if (windowIsDefined) {
+      if (isInBrowser()) {
         window.removeEventListener('resize', handleResize);
       }
     };

--- a/src/utils/environment/environment.js
+++ b/src/utils/environment/environment.js
@@ -1,0 +1,3 @@
+export const isInBrowser = () => typeof window !== 'undefined';
+
+export default { isInBrowser };

--- a/src/utils/environment/environment.spec.js
+++ b/src/utils/environment/environment.spec.js
@@ -1,0 +1,23 @@
+import { isInBrowser } from './environment';
+
+describe('isInBrowser', () => {
+  let windowObj = {};
+
+  beforeEach(() => {
+    windowObj = global.window;
+  });
+
+  afterEach(() => {
+    global.window = windowObj;
+  });
+
+  it('should return false if not running in the browser', () => {
+    delete global.window;
+
+    expect(isInBrowser()).toBe(false);
+  });
+
+  it('should return true if running in the browser', () => {
+    expect(isInBrowser()).toBe(true);
+  });
+});

--- a/src/utils/environment/index.js
+++ b/src/utils/environment/index.js
@@ -1,0 +1,5 @@
+import { isInBrowser } from './environment';
+
+export { isInBrowser };
+
+export default { isInBrowser };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,14 +1,17 @@
+import isInBrowser from './environment';
 import objects from './objects';
 import paragraphsFromDivs from './paragraphsFromDivs';
 import product from './product';
 import viewports from './viewports';
 
+export { isInBrowser };
 export { objects };
 export { paragraphsFromDivs };
 export { product };
 export { viewports };
 
 export default {
+  isInBrowser,
   objects,
   paragraphsFromDivs,
   product,

--- a/src/utils/viewports/viewports.js
+++ b/src/utils/viewports/viewports.js
@@ -1,4 +1,5 @@
 import { BREAKPOINTS } from '~/constants';
+import { isInBrowser } from '~/utils/environment';
 
 export const IS_VIEWPORT_SMALL_ONLY = `(max-width: ${BREAKPOINTS.SMALL.MAX_WIDTH}px)`;
 export const IS_VIEWPORT_MEDIUM = `(min-width: ${BREAKPOINTS.MEDIUM.MIN_WIDTH}px)`;
@@ -61,59 +62,43 @@ export const getViewportForWidth = width => {
 };
 
 export const ascertainIsSmallOnlyViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_SMALL_ONLY).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_SMALL_ONLY).matches : false;
 
 export const ascertainIsSmallOrMediumOnlyViewport = () =>
-  typeof window !== 'undefined'
+  isInBrowser()
     ? window.matchMedia(IS_VIEWPORT_SMALL_MEDIUM_ONLY).matches
     : false;
 
 export const ascertainIsMediumViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_MEDIUM).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_MEDIUM).matches : false;
 
 export const ascertainIsMediumOnlyViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_MEDIUM_ONLY).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_MEDIUM_ONLY).matches : false;
 
 export const ascertainIsLargeViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_LARGE).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_LARGE).matches : false;
 
 export const ascertainIsLargeOnlyViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_LARGE_ONLY).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_LARGE_ONLY).matches : false;
 
 export const ascertainIsLargeOrXLargeOnlyViewport = () =>
-  typeof window !== 'undefined'
+  isInBrowser()
     ? window.matchMedia(IS_VIEWPORT_LARGE_XLARGE_ONLY).matches
     : false;
 
 export const ascertainIsXLargeViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_XLARGE).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_XLARGE).matches : false;
 
 export const ascertainIsSmallToXLargeViewport = () =>
-  typeof window !== 'undefined'
+  isInBrowser()
     ? window.matchMedia(IS_VIEWPORT_SMALL_TO_XLARGE_ONLY).matches
     : false;
 
 export const ascertainIsXLargeOnlyViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_XLARGE_ONLY).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_XLARGE_ONLY).matches : false;
 
 export const ascertainIsXXLargeViewport = () =>
-  typeof window !== 'undefined'
-    ? window.matchMedia(IS_VIEWPORT_XXLARGE).matches
-    : false;
+  isInBrowser() ? window.matchMedia(IS_VIEWPORT_XXLARGE).matches : false;
 
 export default {
   CONSTRAINT_KEYS,


### PR DESCRIPTION
These changes are related to issue #266 for our roadmap to SSR. This PR removes direct window access or wraps them in a condition to ensure they don't execute on the server where `window` is not defined.