### PR TITLE
chore: remove deprecated set-env call

### DIFF
--- a/.github/workflows/update-webui.yml
+++ b/.github/workflows/update-webui.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Create variables
         run: |
-          echo "::set-env name=GEL_VERSION::${GITHUB_REF#refs/*/}"
+          echo "GEL_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Checkout Web UI
         uses: actions/checkout@v2


### PR DESCRIPTION
Set env variable using the new specified way [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)

I tried this with a test tag and you can see the logs [here](https://github.com/aesop/aesop-gel/runs/1439647915?check_suite_focus=true). I cancelled the job before it raised a PR on web ui.

![image](https://user-images.githubusercontent.com/33766083/99921387-2ed87900-2d7e-11eb-95b4-714ef805068a.png)
