### PR TITLE
fix: incorrect window check

### DIFF
--- a/src/customHooks/useOnScreen.js
+++ b/src/customHooks/useOnScreen.js
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react';
 import { isInBrowser } from '~/utils/environment';
 
 const hasIntersectionObserver =
-  (isInBrowser() && 'IntersectionObserver' in window) ||
-  'IntersectionObserverEntry' in window ||
-  ('IntersectionObserverEntry' in window &&
-    'intersectionRatio' in window.IntersectionObserverEntry.prototype);
+  isInBrowser() &&
+  ('IntersectionObserver' in window ||
+    'IntersectionObserverEntry' in window ||
+    ('IntersectionObserverEntry' in window &&
+      'intersectionRatio' in window.IntersectionObserverEntry.prototype));
 
 export const useOnScreen = (
   ref,


### PR DESCRIPTION
The `isBrowser` check was only included for the first condition, this change makes it before all conditions.