### PR TITLE
[Feature][AES-2257] `hasSerifFontHeading` prop for MediaWithContent component

### DIFF
--- a/src/components/MediaWithContent/MediaWithContent.js
+++ b/src/components/MediaWithContent/MediaWithContent.js
@@ -15,6 +15,7 @@ const MediaWithContent = forwardRef(function MediaWithContentRef(
     foregroundImage,
     foregroundImageLink,
     hasFullWidthImage,
+    hasSerifFontHeading,
     hasTopOffset,
     isHero,
     isReverse,
@@ -48,6 +49,7 @@ const MediaWithContent = forwardRef(function MediaWithContentRef(
         content={content}
         copy={copy}
         hasFullWidthImage={hasFullWidthImage}
+        hasSerifFontHeading={hasSerifFontHeading}
         hasTopOffset={hasTopOffset}
         isHero={isHero}
         isReverse={isReverse}
@@ -71,6 +73,7 @@ MediaWithContent.propTypes = {
   foregroundImage: PropTypes.element,
   foregroundImageLink: PropTypes.object,
   hasFullWidthImage: PropTypes.bool,
+  hasSerifFontHeading: PropTypes.bool,
   hasTopOffset: PropTypes.bool,
   isHero: PropTypes.bool,
   isReverse: PropTypes.bool,
@@ -92,6 +95,7 @@ MediaWithContent.defaultProps = {
   foregroundImage: undefined,
   foregroundImageLink: undefined,
   hasFullWidthImage: false,
+  hasSerifFontHeading: true,
   hasTopOffset: false,
   isHero: false,
   isReverse: false,

--- a/src/components/MediaWithContent/components/Content/Content.js
+++ b/src/components/MediaWithContent/components/Content/Content.js
@@ -10,6 +10,7 @@ const Content = ({
   content,
   copy,
   hasFullWidthImage,
+  hasSerifFontHeading,
   hasTopOffset,
   isHero,
   isReverse,
@@ -36,7 +37,7 @@ const Content = ({
           }}
           className={styles.header}
           eyebrow={copy.eyebrow}
-          hasSerifFontHeading={true}
+          hasSerifFontHeading={hasSerifFontHeading}
           heading={copy.heading}
           isFlush={!isHero}
           isPageHeading={isHero}
@@ -70,6 +71,7 @@ Content.propTypes = {
     subHeading: PropTypes.string,
   }).isRequired,
   hasFullWidthImage: PropTypes.bool,
+  hasSerifFontHeading: PropTypes.bool,
   hasTopOffset: PropTypes.bool,
   isHero: PropTypes.bool,
   isReverse: PropTypes.bool,
@@ -86,6 +88,7 @@ Content.defaultProps = {
     subHeading: undefined,
   },
   hasFullWidthImage: false,
+  hasSerifFontHeading: true,
   hasTopOffset: false,
   isHero: false,
   isReverse: false,


### PR DESCRIPTION
To help address https://aesoponline.atlassian.net/browse/AES-2257 this PR adds a `hasSerifFontHeading` prop to the MediaWithContent component