### PR TITLE
fix: update carousel prop types

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -233,7 +233,7 @@ Carousel.propTypes = {
       url: PropTypes.string,
       text: PropTypes.string,
     }),
-    description: PropTypes.string,
+    description: PropTypes.node,
     eyebrow: PropTypes.string,
     heading: PropTypes.string,
   }),

--- a/src/components/Carousel/components/CarouselIntroduction/CarouselIntroduction.js
+++ b/src/components/Carousel/components/CarouselIntroduction/CarouselIntroduction.js
@@ -56,7 +56,7 @@ CarouselIntroduction.propTypes = {
     url: PropTypes.string,
     text: PropTypes.string,
   }),
-  description: PropTypes.string,
+  description: PropTypes.node,
   heading: PropTypes.string,
   theme: PropTypes.oneOf(['dark', 'light']),
   eyebrow: PropTypes.string,


### PR DESCRIPTION
Most of the time the slide description is just a `string`, however, sometimes it's a react node. This change allows the component to accept both