### PR TITLE
chore(compboilerplate): fix import statement

### DIFF
--- a/scripts/componentBoilerplate/assets/index.js
+++ b/scripts/componentBoilerplate/assets/index.js
@@ -1,3 +1,3 @@
-import ComponentBoilerplate from './ComponentBoilerplate';
+import { ComponentBoilerplate } from './ComponentBoilerplate';
 
 export { ComponentBoilerplate };


### PR DESCRIPTION
Because the components are now exported as named exports, the existing import statement breaks. 