### PR TITLE
Improve form element styles

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -34,7 +34,7 @@ const Checkbox = forwardRef(
     const errorMessageId = `${inputId}-error-message`;
 
     return (
-      <React.Fragment>
+      <div>
         <label className={baseClassSet} htmlFor={inputId}>
           <input
             aria-describedby={errorMessageId}
@@ -55,7 +55,7 @@ const Checkbox = forwardRef(
             {errorMessage}
           </span>
         )}
-      </React.Fragment>
+      </div>
     );
   },
 );

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -2,24 +2,26 @@
 
 exports[`<Checkbox /> should render base component correctly 1`] = `
 <div>
-  <label
-    class="base"
-    for="test-checkbox"
-  >
-    <input
-      aria-describedby="test-checkbox-error-message"
-      aria-invalid="false"
-      class="checkBox dark"
-      data-test-ref="test-data-ref"
-      disabled=""
-      id="test-checkbox"
-      type="checkbox"
-    />
-    <span
-      class="content dark"
+  <div>
+    <label
+      class="base"
+      for="test-checkbox"
     >
-      Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
-    </span>
-  </label>
+      <input
+        aria-describedby="test-checkbox-error-message"
+        aria-invalid="false"
+        class="checkBox dark"
+        data-test-ref="test-data-ref"
+        disabled=""
+        id="test-checkbox"
+        type="checkbox"
+      />
+      <span
+        class="content dark"
+      >
+        Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
+      </span>
+    </label>
+  </div>
 </div>
 `;

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -30,10 +30,14 @@
   border-radius: 0;
   color: var(--color-dark-copy);
   cursor: pointer;
-  font-size: rem(24px);
+  font-size: rem(20px);
   line-height: 1.5;
   outline: none;
   text-overflow: ellipsis;
+
+  @media (--viewport-md) {
+    font-size: rem(24px);
+  }
 
   .dark & {
     color: var(--color-dark-copy);
@@ -70,10 +74,14 @@
 .label {
   position: absolute;
   top: 0;
-  font-size: rem(24px);
+  font-size: rem(20px);
   pointer-events: none;
   transform: translateY(25px);
   transition: all 300ms cubic-bezier(0.215, 0.61, 0.355, 1);
+
+  @media (--viewport-md) {
+    font-size: rem(24px);
+  }
 
   .dark & {
     color: var(--color-dark-label);

--- a/src/components/TextInputV2/TextInputV2.module.css
+++ b/src/components/TextInputV2/TextInputV2.module.css
@@ -31,7 +31,7 @@
   left: 0;
   line-height: 1.75;
   pointer-events: none;
-  transition: all 0.2s var(--easing-ease-in-out-cubic);
+  transition: all 300ms var(--easing-ease-in-out-cubic);
 
   &.dark {
     color: var(--color-dark-label);
@@ -50,7 +50,6 @@
   @mixin inputFontSize;
 
   width: 100%;
-  height: 40px;
   padding: 0;
   border: 0;
   border-width: 0 0 1px;
@@ -59,6 +58,7 @@
   appearance: none;
   background-color: transparent;
   border-radius: 0;
+  line-height: 1.5;
   text-overflow: ellipsis;
 
   &.dark {

--- a/src/compositions/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/compositions/Footer/__snapshots__/Footer.spec.js.snap
@@ -109,42 +109,46 @@ exports[`<Footer /> should render base component correctly 1`] = `
               class="footerNewsletterErrorMessage"
             />
             <section>
-              <label
-                class="base"
-                for="subscription"
-              >
-                <input
-                  aria-describedby="subscription-error-message"
-                  aria-invalid="false"
-                  class="checkBox light"
-                  data-test-ref="EMAIL_SIGN_UP_SUBSCRIPTION_CHECKBOX"
-                  id="subscription"
-                  type="checkbox"
-                />
-                <span
-                  class="content light"
+              <div>
+                <label
+                  class="base"
+                  for="subscription"
                 >
-                  Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
-                </span>
-              </label>
-              <label
-                class="base"
-                for="terms"
-              >
-                <input
-                  aria-describedby="terms-error-message"
-                  aria-invalid="false"
-                  class="checkBox light"
-                  data-test-ref="EMAIL_SIGN_UP_TERMS_AND_CONDITIONS_CHECKBOX"
-                  id="terms"
-                  type="checkbox"
-                />
-                <span
-                  class="content light"
+                  <input
+                    aria-describedby="subscription-error-message"
+                    aria-invalid="false"
+                    class="checkBox light"
+                    data-test-ref="EMAIL_SIGN_UP_SUBSCRIPTION_CHECKBOX"
+                    id="subscription"
+                    type="checkbox"
+                  />
+                  <span
+                    class="content light"
+                  >
+                    Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
+                  </span>
+                </label>
+              </div>
+              <div>
+                <label
+                  class="base"
+                  for="terms"
                 >
-                  I accept the Terms & Conditions 
-                </span>
-              </label>
+                  <input
+                    aria-describedby="terms-error-message"
+                    aria-invalid="false"
+                    class="checkBox light"
+                    data-test-ref="EMAIL_SIGN_UP_TERMS_AND_CONDITIONS_CHECKBOX"
+                    id="terms"
+                    type="checkbox"
+                  />
+                  <span
+                    class="content light"
+                  >
+                    I accept the Terms & Conditions 
+                  </span>
+                </label>
+              </div>
               <div
                 class="termsAndConditionWrapper"
               >

--- a/src/compositions/NewsletterSignUp/__snapshots__/NewsletterSignUp.spec.js.snap
+++ b/src/compositions/NewsletterSignUp/__snapshots__/NewsletterSignUp.spec.js.snap
@@ -65,42 +65,46 @@ exports[`<NewsletterSignUp /> should render base component correctly 1`] = `
         class="footerNewsletterErrorMessage"
       />
       <section>
-        <label
-          class="base"
-          for="subscription"
-        >
-          <input
-            aria-describedby="subscription-error-message"
-            aria-invalid="false"
-            class="checkBox light"
-            data-test-ref="EMAIL_SIGN_UP_SUBSCRIPTION_CHECKBOX"
-            id="subscription"
-            type="checkbox"
-          />
-          <span
-            class="content light"
+        <div>
+          <label
+            class="base"
+            for="subscription"
           >
-            Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
-          </span>
-        </label>
-        <label
-          class="base"
-          for="terms"
-        >
-          <input
-            aria-describedby="terms-error-message"
-            aria-invalid="false"
-            class="checkBox light"
-            data-test-ref="EMAIL_SIGN_UP_TERMS_AND_CONDITIONS_CHECKBOX"
-            id="terms"
-            type="checkbox"
-          />
-          <span
-            class="content light"
+            <input
+              aria-describedby="subscription-error-message"
+              aria-invalid="false"
+              class="checkBox light"
+              data-test-ref="EMAIL_SIGN_UP_SUBSCRIPTION_CHECKBOX"
+              id="subscription"
+              type="checkbox"
+            />
+            <span
+              class="content light"
+            >
+              Subscribe to communications about Aesop products, services, stores, events and matters of cultural interest.
+            </span>
+          </label>
+        </div>
+        <div>
+          <label
+            class="base"
+            for="terms"
           >
-            I accept the Terms & Conditions 
-          </span>
-        </label>
+            <input
+              aria-describedby="terms-error-message"
+              aria-invalid="false"
+              class="checkBox light"
+              data-test-ref="EMAIL_SIGN_UP_TERMS_AND_CONDITIONS_CHECKBOX"
+              id="terms"
+              type="checkbox"
+            />
+            <span
+              class="content light"
+            >
+              I accept the Terms & Conditions 
+            </span>
+          </label>
+        </div>
         <div
           class="termsAndConditionWrapper"
         >


### PR DESCRIPTION
This PR makes some small changes to form components to pave the way for them to be used together. The changes are:
* Checkbox: wrap in `div` instead of `Fragment` to ensure the error message is always displayed under the label and never next to it
* Select:  reduce the font size on smaller viewports
* InputTextV2: change styles (transition duration, line height) to match Select