### PR TITLE
Specify node version in GH action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v2
+        with:
+          # need at least 10.18.0 for semantic release
+          node-version: '10.18.0'
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
This is another attempt to address the intermittent issue we get on GH where it fails to run `npm ci`.

I noticed that currently (on `develop`) the node version used in GH is 14.x. However, Gel uses `10.16.0`. This PR specifies version 10.18.0 to be used (a note on that later). I ran the GH action for this commit 4 times and it passed every time, hopefully this does it 🤞 

Note: originally I tried using node v 10.16.0 to match what's used by Gel, however, `semantic-release` requires version 10.18.0 or higher.  That's why I went with 10.18.0.

![image](https://user-images.githubusercontent.com/33766083/106398946-f33ae900-6469-11eb-9eb8-0330df7f873d.png)
