### PR TITLE
chore: add text-summary to the reporters

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
       lines: 84,
     },
   },
+  coverageReporters: ['lcov', 'text', 'text-summary'],
   moduleFileExtensions: ['js', 'json', 'node'],
   testPathIgnorePatterns: [
     '<rootDir>/(dist|docs|node_modules|.cache)/',


### PR DESCRIPTION
This adds the 'text-summary' test coverage reported. The reporter just prints to the console the overall coverage percentages. It can be seen [here](https://github.com/aesop/aesop-gel/pull/306/checks?check_run_id=1803094628#step:6:352) in the build logs for this commit.