### PR TITLE
Automate GH Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,40 @@
+name: Deploy Storybook to GH Pages
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy_storybook:
+    name: Deploy Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10.16.0'
+
+      - name: Store tag name
+        run: |
+          echo "GEL_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # to address https://github.com/actions/checkout/issues/13 and
+      # https://github.com/tschaub/gh-pages/issues/230#issue-300188493
+      - name: Set Git config
+        env:
+          GITHUB_TOKEN: ${{ secrets.X_GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "Storybook Deployer"
+          git config --global user.email " "
+          git remote set-url origin "https://${GITHUB_TOKEN}@github.com/aesop/aesop-gel.git"
+
+      - name: Install
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook -- --quiet
+
+      - name: Deploy to GH Pages
+        run: npm run deploy-storybook -- --message "Update GH Pages to Gel version ${GEL_VERSION}"


### PR DESCRIPTION
This PR creates a GH workflow that will run every time a git version tag is pushed. It will update the Storybook preview deployed at https://aesop.github.io/aesop-gel/.

Test run:
* logs: https://github.com/aesop/aesop-gel/actions/runs/546945704
* commit pushed to gh-pages branch: https://github.com/aesop/aesop-gel/commit/e173e448060a9b5db5fed90456ec86bad50069f4


*Note*: this [workflow](https://github.com/aesop/aesop-gel/pull/312/checks?check_run_id=1852136884) failed because I deleted the tag before it check it out. And I cancelled this [workflow](https://github.com/aesop/aesop-gel/pull/312/checks?check_run_id=1852128677) as it's not needed.