### PR TITLE
Allow running deployment manually

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - v*
 
+  workflow_dispatch:
+
 jobs:
   deploy_storybook:
     name: Deploy Storybook


### PR DESCRIPTION
GH workflows [can be triggered manually](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch). 

This PR adds the ability to trigger deployment to GH Pages manually. The UI will look like this
![image](https://user-images.githubusercontent.com/33766083/107287940-cbc1cd00-6ab6-11eb-9faf-34effc6d2fb9.png)
