### PR TITLE
[Chore] Replace uuid with react-uid in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^16.8.0",
     "react-hook-form": "^6.14.1",
     "react-slick": "0.25.2",
-    "uuid": "8.3.1",
+    "react-uid": "^2.3.1",
     "wavesurfer.js": "3.3.3"
   },
   "dependencies": {


### PR DESCRIPTION
As per title, the PR replaces `uuid` with `react-uid` in peer dependencies