### PR TITLE
feat: lazy load external npm modules

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,10 +51,6 @@ export default {
     json(),
     commonjs(),
     nodeResolve(),
-    terser({
-      output: {
-        comments: /.*webpack.*/i, // keep webpack magic comments
-      },
-    }),
+    terser(),
   ],
 };

--- a/src/components/Audio/Audio.customHooks.js
+++ b/src/components/Audio/Audio.customHooks.js
@@ -13,10 +13,7 @@ const useWaveSurfer = (progressColor, hasAutoPlay) => {
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
-    import(
-      /* webpackMode: "eager" */
-      'wavesurfer.js'
-    ).then(module => {
+    import('wavesurfer.js').then(module => {
       const WaveSurfer = module.default || module;
 
       if (waveformRef.current) {

--- a/src/contexts/GoogleMapsContext/GoogleMapsStore.js
+++ b/src/contexts/GoogleMapsContext/GoogleMapsStore.js
@@ -13,7 +13,7 @@ const useGoogleMapsStore = (apiKey, options = { libraries: ['places'] }) => {
 
   useEffect(() => {
     const loadGoogleMap = async () => {
-      const module = await import(/* webpackMode: "eager" */ 'google-maps');
+      const module = await import('google-maps');
       const Loader = module.default || module;
 
       setIsLoading(true);


### PR DESCRIPTION
Previously, dynamic (lazy) loading of modules was not working on Aesop Web UI, so it was necessary to instruct webpack to load them at the start. However, now it is working so there is no need to do this. This change should also reduce our initial bundle size especially that these components are seldom used.

Happy to demo dynamic module loading if anyone wants to see it in action.