### PR TITLE
fix: wrap document access in window check

### DIFF
--- a/src/components/FlyinPanel/FlyinPanel.js
+++ b/src/components/FlyinPanel/FlyinPanel.js
@@ -8,12 +8,20 @@ import { Heading } from '~/components/Heading';
 import { Icon } from '~/components/Icon';
 import { Overlay } from '~/components/Overlay';
 import { Transition } from '~/components/Transition';
+import { isInBrowser } from '~/utils/environment';
 import styles from './FlyinPanel.module.css';
 
-/** Set up the Flyin component's anchor point for ReactDOM.createPortal */
-const modalRoot = document.createElement('div');
-modalRoot.setAttribute('id', 'aesop-gel-flyin-root');
-document.body.appendChild(modalRoot);
+let modalRoot = null;
+if (isInBrowser()) {
+  /** Set up the Flyin component's anchor point for ReactDOM.createPortal */
+  modalRoot = document.getElementById('aesop-gel-flyin-root');
+
+  if (!modalRoot) {
+    modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'aesop-gel-flyin-root');
+    document.body.appendChild(modalRoot);
+  }
+}
 
 const FlyinPanel = ({
   children,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -6,15 +6,19 @@ import { useEscapeKeyListener, useOverflowHidden } from '~/customHooks';
 import { ModalBody } from './components/ModalBody';
 import { Overlay } from '~/components/Overlay';
 import { Transition } from '~/components/Transition';
+import { isInBrowser } from '~/utils/environment';
 import styles from './Modal.module.css';
 
-/** Set up the Modal component's anchor point for ReactDOM.createPortal */
-let modalRoot = document.getElementById('aesop-gel-modal-root');
+let modalRoot = null;
+if (isInBrowser()) {
+  /** Set up the Modal component's anchor point for ReactDOM.createPortal */
+  modalRoot = document.getElementById('aesop-gel-modal-root');
 
-if (!modalRoot) {
-  modalRoot = document.createElement('div');
-  modalRoot.setAttribute('id', 'aesop-gel-modal-root');
-  document.body.appendChild(modalRoot);
+  if (!modalRoot) {
+    modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'aesop-gel-modal-root');
+    document.body.appendChild(modalRoot);
+  }
 }
 
 const Modal = ({ children, className, copy, isVisible, onClose, theme }) => {


### PR DESCRIPTION
Access to the `document` without a check is causing errors when Gel is used outside the browser (i.e. NextJS). This change wraps them in a check to prevent execution unless in the browser.