### PR TITLE
Rrefactor to new conventions

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -10,8 +10,8 @@ import {
 import { Collapse } from 'react-collapse';
 import { Icon } from '~/components/Icon';
 import { isObjectPopulatedArray } from '~/utils/objects';
-import styles from './Accordion.module.css';
 import type { AccordionProps } from './Accordion.types';
+import styles from './Accordion.module.css';
 
 const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   ({ className, id, items, theme = 'dark', wrapperClass }, ref) => {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -11,9 +11,9 @@ import { Collapse } from 'react-collapse';
 import { Icon } from '~/components/Icon';
 import { isObjectPopulatedArray } from '~/utils/objects';
 import styles from './Accordion.module.css';
-import type { Props } from './Accordion.types';
+import type { AccordionProps } from './Accordion.types';
 
-const Accordion = forwardRef<HTMLDivElement, Props>(
+const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   ({ className, id, items, theme = 'dark', wrapperClass }, ref) => {
     const [activeNodes, setIsActiveNodes] = React.useState([]);
 

--- a/src/components/Accordion/Accordion.types.tsx
+++ b/src/components/Accordion/Accordion.types.tsx
@@ -1,18 +1,18 @@
 import { ReactNode } from 'react';
 import type { Themes } from '~/types';
 
-type GelAccordionItem = {
+type AccordionItem = {
   content: ReactNode;
   heading: string;
   id: string;
 };
 
-type Props = {
+type AccordionProps = {
   className?: string;
   id?: string;
-  items?: GelAccordionItem[];
+  items?: AccordionItem[];
   theme?: Themes;
   wrapperClass?: string;
 };
 
-export type { Props };
+export type { AccordionProps };

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import cx from 'classnames';
-import type { Props } from './Figure.types';
+import type { FigureProps } from './Figure.types';
 import styles from './Figure.module.css';
 
-const Figure: FC<Props> = ({
+const Figure: FC<FigureProps> = ({
   caption,
   children,
   className,

--- a/src/components/Figure/Figure.types.ts
+++ b/src/components/Figure/Figure.types.ts
@@ -1,4 +1,4 @@
-type Props = {
+type FigureProps = {
   caption?: string;
   children?: React.ReactNode;
   className?: string;
@@ -9,4 +9,4 @@ type Props = {
   foo?: boolean;
 };
 
-export type { Props };
+export type { FigureProps };

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import cx from 'classnames';
 import { useThemeContext } from '~/contexts';
-import styles from './Heading.module.css';
 import type { HeadingProps } from './Heading.types';
+import styles from './Heading.module.css';
 
 const Heading: FC<HeadingProps> = ({
   children,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -2,9 +2,9 @@ import React, { FC } from 'react';
 import cx from 'classnames';
 import { useThemeContext } from '~/contexts';
 import styles from './Heading.module.css';
-import type { Props } from './Heading.types';
+import type { HeadingProps } from './Heading.types';
 
-const Heading: FC<Props> = ({
+const Heading: FC<HeadingProps> = ({
   children,
   className,
   hasMediumWeightFont = false,

--- a/src/components/Heading/Heading.types.ts
+++ b/src/components/Heading/Heading.types.ts
@@ -4,7 +4,7 @@ type Levels = '1' | '2' | '3' | '4' | '5' | '6';
 
 type Sizes = 'xXSmall' | 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
 
-type Props = {
+type HeadingProps = {
   children: React.ReactNode;
   className?: string;
   hasMediumWeightFont?: boolean;
@@ -16,4 +16,4 @@ type Props = {
   theme?: Themes;
 };
 
-export type { Props };
+export type { HeadingProps };

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -3,10 +3,10 @@ import cx from 'classnames';
 import get from 'lodash/get';
 import { constraintsByViewport } from '~/utils/viewports';
 import { Hyperlink } from '~/components/Hyperlink';
-import type { Props } from './Image.types';
+import type { ImageProps } from './Image.types';
 import styles from './Image.module.css';
 
-const Image: FC<Props> = forwardRef(function ImageRef(
+const Image: FC<ImageProps> = forwardRef(function ImageRef(
   {
     altText,
     className,

--- a/src/components/Image/Image.types.ts
+++ b/src/components/Image/Image.types.ts
@@ -1,7 +1,7 @@
 import { CSSProperties } from 'react';
 import type { Themes } from '~/types';
 
-type Props = {
+type ImageProps = {
   altText?: string;
   className?: string;
   cta?: {
@@ -19,4 +19,4 @@ type Props = {
   theme?: Themes;
 };
 
-export type { Props };
+export type { ImageProps };

--- a/src/components/Paragraph/Paragraph.tsx
+++ b/src/components/Paragraph/Paragraph.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import cx from 'classnames';
-import styles from './Paragraph.module.css';
 import type { ParagraphProps, ParagraphSetProps } from './Paragraph.types';
+import styles from './Paragraph.module.css';
 
 const Paragraph: FC<ParagraphProps> = ({
   children,

--- a/src/contexts/AddToCartContext/AddToCartContext.tsx
+++ b/src/contexts/AddToCartContext/AddToCartContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useAddToCartStore } from './AddToCartStore';
-import type { Props } from './AddToCartContext.types';
+import type { AddToCartContextProps } from './AddToCartContext.types';
 
 const AddToCartContext = createContext(undefined);
 
-const AddToCartContextProvider: FC<Props> = ({ children, onClick }) => (
+const AddToCartContextProvider: FC<AddToCartContextProps> = ({
+  children,
+  onClick,
+}) => (
   <AddToCartContext.Provider value={useAddToCartStore(onClick)}>
     {children}
   </AddToCartContext.Provider>

--- a/src/contexts/AddToCartContext/AddToCartContext.types.ts
+++ b/src/contexts/AddToCartContext/AddToCartContext.types.ts
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 
-type Props = {
+type AddToCartContextProps = {
   /**
     A callback function that takes `sku<string>`, `addToCartDispatch<function>`, `ADD_TO_CART_ACTION_TYPES<array[string]>`
     as arguments. See [AddToCartButton.onClick.js mock](https://github.com/aesop/aesop-gel/tree/develop/src/components/AddToCartButton/__mocks__/AddToCartButton.onClick.js)
@@ -9,4 +9,4 @@ type Props = {
   onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export type { Props };
+export type { AddToCartContextProps };

--- a/src/contexts/GoogleMapsContext/GoogleMapsContext.tsx
+++ b/src/contexts/GoogleMapsContext/GoogleMapsContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useGoogleMapsStore } from './GoogleMapsStore';
-import type { Props } from './GoogleMapsContext.types';
+import type { GoogleMapsContextProps } from './GoogleMapsContext.types';
 
 const defaultValues = {
   googleMap: null,
@@ -9,7 +9,7 @@ const defaultValues = {
 
 const GoogleMapsContext = createContext(defaultValues);
 
-const GoogleMapsContextProvider: FC<Props> = ({
+const GoogleMapsContextProvider: FC<GoogleMapsContextProps> = ({
   apiKey,
   children,
   options,

--- a/src/contexts/GoogleMapsContext/GoogleMapsContext.types.ts
+++ b/src/contexts/GoogleMapsContext/GoogleMapsContext.types.ts
@@ -4,9 +4,9 @@ type Options = {
   languageCode?: string;
 };
 
-type Props = {
+type GoogleMapsContextProps = {
   apiKey?: string;
   options?: Options;
 };
 
-export type { Props, Options };
+export type { GoogleMapsContextProps, Options };

--- a/src/contexts/LoadMoreContext/LoadMoreContext.tsx
+++ b/src/contexts/LoadMoreContext/LoadMoreContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useLoadMoreStore } from './LoadMoreStore';
-import type { Props } from './LoadMoreContext.types';
+import type { LoadMoreContextProps } from './LoadMoreContext.types';
 
 const LoadMoreContext = createContext(undefined);
 
-const LoadMoreContextProvider: FC<Props> = ({ children, onClick }) => (
+const LoadMoreContextProvider: FC<LoadMoreContextProps> = ({
+  children,
+  onClick,
+}) => (
   <LoadMoreContext.Provider value={useLoadMoreStore(onClick)}>
     {children}
   </LoadMoreContext.Provider>

--- a/src/contexts/LoadMoreContext/LoadMoreContext.types.ts
+++ b/src/contexts/LoadMoreContext/LoadMoreContext.types.ts
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 
-type Props = {
+type LoadMoreContextProps = {
   /**
     A callback function that takes `sku<string>`, `LoadMoreDispatch<function>`, `ADD_TO_CART_ACTION_TYPES<array[string]>`
     as arguments. See [LoadMoreButton.onClick.js mock](https://github.com/aesop/aesop-gel/tree/develop/src/components/LoadMoreButton/__mocks__/LoadMoreButton.onClick.js)
@@ -9,4 +9,4 @@ type Props = {
   onClick: MouseEventHandler<HTMLButtonElement>;
 };
 
-export type { Props };
+export type { LoadMoreContextProps };

--- a/src/contexts/NavBarThemeContext/NavBarThemeContext.tsx
+++ b/src/contexts/NavBarThemeContext/NavBarThemeContext.tsx
@@ -1,10 +1,10 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useNavBarThemeStore } from './NavBarThemeStore';
-import type { Props } from './NavBarThemeContext.types';
+import type { NavBarThemeContextProps } from './NavBarThemeContext.types';
 
 const NavBarThemeContext = createContext(undefined);
 
-const NavBarThemeContextProvider: FC<Props> = ({
+const NavBarThemeContextProvider: FC<NavBarThemeContextProps> = ({
   children,
   loginAndCartTheme,
   navigationAndLogoTheme,

--- a/src/contexts/NavBarThemeContext/NavBarThemeContext.types.ts
+++ b/src/contexts/NavBarThemeContext/NavBarThemeContext.types.ts
@@ -1,6 +1,6 @@
-type Props = {
+type NavBarThemeContextProps = {
   loginAndCartTheme?: string;
   navigationAndLogoTheme?: string;
 };
 
-export type { Props };
+export type { NavBarThemeContextProps };

--- a/src/contexts/ProductDetailContext/ProductDetailContext.tsx
+++ b/src/contexts/ProductDetailContext/ProductDetailContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useProductDetailStore } from './ProductDetailStore';
-import type { Props } from './ProductDetailContext.types';
+import type { ProductDetailContextProps } from './ProductDetailContext.types';
 
 const ProductDetailContext = createContext(undefined);
 
-const ProductDetailContextProvider: FC<Props> = ({ children, product }) => (
+const ProductDetailContextProvider: FC<ProductDetailContextProps> = ({
+  children,
+  product,
+}) => (
   <ProductDetailContext.Provider value={useProductDetailStore(product)}>
     {children}
   </ProductDetailContext.Provider>

--- a/src/contexts/ProductDetailContext/ProductDetailContext.types.ts
+++ b/src/contexts/ProductDetailContext/ProductDetailContext.types.ts
@@ -1,7 +1,7 @@
 import { Product } from '~/types';
 
-type Props = {
+type ProductDetailContextProps = {
   product?: Product;
 };
 
-export { Props };
+export { ProductDetailContextProps };

--- a/src/contexts/ThemeContext/ThemeContext.tsx
+++ b/src/contexts/ThemeContext/ThemeContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, FC } from 'react';
-import type { Props } from './ThemeContext.types';
+import type { ThemeContextProps } from './ThemeContext.types';
 
 const ThemeContext = createContext(undefined);
 
-const ThemeContextProvider: FC<Props> = ({ children, theme }) => (
+const ThemeContextProvider: FC<ThemeContextProps> = ({ children, theme }) => (
   <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 );
 

--- a/src/contexts/ThemeContext/ThemeContext.types.ts
+++ b/src/contexts/ThemeContext/ThemeContext.types.ts
@@ -1,7 +1,7 @@
 import { Themes } from '~/types';
 
-type Props = {
+type ThemeContextProps = {
   theme?: Themes;
 };
 
-export { Props };
+export { ThemeContextProps };

--- a/src/contexts/VariantSelectContext/VariantSelectContext.tsx
+++ b/src/contexts/VariantSelectContext/VariantSelectContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext, FC } from 'react';
 import { useVariantSelectStore } from './VariantSelectStore';
-import type { Props } from './VariantSelectContext.types';
+import type { VariantSelectContextProps } from './VariantSelectContext.types';
 
 const VariantSelectContext = createContext(undefined);
 
-const VariantSelectContextProvider: FC<Props> = ({ children, variants }) => (
+const VariantSelectContextProvider: FC<VariantSelectContextProps> = ({
+  children,
+  variants,
+}) => (
   <VariantSelectContext.Provider value={useVariantSelectStore(variants)}>
     {children}
   </VariantSelectContext.Provider>

--- a/src/contexts/VariantSelectContext/VariantSelectContext.types.ts
+++ b/src/contexts/VariantSelectContext/VariantSelectContext.types.ts
@@ -1,7 +1,7 @@
 import type { Variant } from '~/types';
 
-type Props = {
+type VariantSelectContextProps = {
   variants: Variant[];
 };
 
-export type { Props };
+export type { VariantSelectContextProps };


### PR DESCRIPTION
This PR refactors existing TS code to:
1. Prefix `props` with the name of the component/context they're for
2. Move css imports to the last line of imports in the file

Closes #341 