### PR TITLE
Exclude scripts folder from TS compile

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,9 @@ export default {
       babelHelpers: 'bundled',
       exclude: 'node_modules/**',
     }),
-    typescript(),
+    typescript({
+      exclude: ['./scripts/**'],
+    }),
     json(),
     commonjs(),
     nodeResolve(),


### PR DESCRIPTION
This is to address these [errors](https://github.com/aesop/aesop-gel/runs/2081261145?check_suite_focus=true#step:7:17) during the build.