### PR TITLE
Fix React Dom Server dependency in browser

### DIFF
--- a/src/components/GoogleMap/GoogleMap.js
+++ b/src/components/GoogleMap/GoogleMap.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import isFunction from 'lodash/isFunction';
-import ReactDOMServer from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server.browser';
 import MarkerClusterer from '@google/markerclusterer';
 import {
   HYPERLINK_STYLE_TYPES,
@@ -202,7 +202,7 @@ const GoogleMap = ({
       });
 
       const infoCard = new googleMap.maps.InfoWindow({
-        content: ReactDOMServer.renderToString(
+        content: renderToStaticMarkup(
           <InfoCard
             address={address}
             copy={{


### PR DESCRIPTION
Currently, one of the dependencies of the `renderToString` method is the Node Stream module. This isn't an issue at the moment as Webpack v4 (and older) provide a polyfill for it. However, from v5 onwards we'd need to provide our own polyfill for it.

Fortunately, there is a browser friendly alternative provided in the React Dom library. Switching to it remove the `Stream` dependency from the build files as seen in the diff below. In addition to moving to the browser version, I've switched to using `renderToStaticMarkup`. This method is sufficient for our use case as we won't be hydrating the component later and thus don't need `renderToString`.

![image](https://user-images.githubusercontent.com/33766083/111233844-835f7700-8641-11eb-9c72-6b490d84fc9e.png)

I deployed a Web UI branch using this Gel branch [here](https://demo-react-dom-change.acceptance.aesop.com/au). It works in IE too @kevin-ho87 
![image](https://user-images.githubusercontent.com/33766083/111389258-c7678000-8704-11eb-95fc-bef171170559.png)


Closes #344 
