### PR TITLE
ci: using checkout v1 and npm cache to avoid weird build issues

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,12 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
         with:
-          persist-credentials: false
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.15.4'
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
I re-ran this more than 5 times and it passed. Hoping it fixes our build issues 🤞 