### PR TITLE
fix(quote): capture and use the ref argument

### DIFF
--- a/src/components/Quote/Quote.tsx
+++ b/src/components/Quote/Quote.tsx
@@ -4,17 +4,15 @@ import { useThemeContext } from '~/contexts';
 import type { QuoteProps } from './Quote.types';
 import styles from './Quote.module.css';
 
-const Quote = forwardRef<HTMLDivElement, QuoteProps>(function QuoteRef({
-  author,
-  className,
-  content,
-  theme,
-}) {
+const Quote = forwardRef<HTMLDivElement, QuoteProps>(function QuoteRef(
+  { author, className, content, theme },
+  ref,
+) {
   const currentTheme = useThemeContext(theme, 'dark');
   const classSet = cx(styles.base, styles[currentTheme], className);
 
   return (
-    <div className={classSet}>
+    <div className={classSet} ref={ref}>
       <div className={styles.wrapper}>
         <blockquote className={styles.blockquote}>{content}</blockquote>
         <cite className={styles.author}>{author}</cite>


### PR DESCRIPTION
I noticed this error in Web UI
![image](https://user-images.githubusercontent.com/33766083/112915004-17a10200-9149-11eb-8d85-c32ead6a7abb.png)

The stack trace led me to this which looked like the Quote component
![image](https://user-images.githubusercontent.com/33766083/112915089-4e771800-9149-11eb-972f-30690d7452f1.png)
