### PR TITLE
chore: disable update_web_ui workflow

### DIFF
--- a/.github/workflows/tag-push.yml
+++ b/.github/workflows/tag-push.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
 
 env:
   NODE_VERSION: 14.15.4

--- a/.github/workflows/tag-push.yml
+++ b/.github/workflows/tag-push.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   update_web_ui:
+    if: ${{ false }}
     name: Update Web UI
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As the `develop` branch is no longer being used and will be deleted soon I thought we should disable this part of the workflow until we figure out how to update Gel on Web UI.