### PR TITLE
[Feature/CON-188]: add ingredient flyouts 1 and 2 

### DIFF
--- a/src/components/ProductDetailHeader/ProductDetailHeader.js
+++ b/src/components/ProductDetailHeader/ProductDetailHeader.js
@@ -33,6 +33,10 @@ const ProductDetailHeader = ({ breadcrumbs, className, copy, theme }) => {
               size: copy?.size,
               upSellProductLabel: copy?.upSellProductLabel,
               flyinPanelHeading: copy?.flyinPanelHeading,
+              ingredientsFlyoutBoilerplateOne:
+                copy?.ingredientsFlyoutBoilerplateOne,
+              ingredientsFlyoutBoilerplateTwo:
+                copy?.ingredientsFlyoutBoilerplateTwo,
             }}
             theme={currentTheme}
           />
@@ -87,6 +91,8 @@ ProductDetailHeader.propTypes = {
     }),
     upSellProductLabel: PropTypes.string,
     flyinPanelHeading: PropTypes.string,
+    ingredientsFlyoutBoilerplateOne: PropTypes.string,
+    ingredientsFlyoutBoilerplateTwo: PropTypes.string,
   }),
   theme: PropTypes.oneOf(['dark', 'light']),
 };
@@ -100,6 +106,8 @@ ProductDetailHeader.defaultProps = {
   className: undefined,
   copy: {
     addToCart: undefined,
+    ingredientsFlyoutBoilerplateOne: undefined,
+    ingredientsFlyoutBoilerplateTwo: undefined,
     size: {
       singular: undefined,
       plural: undefined,

--- a/src/components/ProductDetailHeader/components/ProductDetailBody/ProductDetailBody.js
+++ b/src/components/ProductDetailHeader/components/ProductDetailBody/ProductDetailBody.js
@@ -237,6 +237,16 @@ const ProductDetailBody = ({ className, copy, theme }) => {
           onClose={handleOnCloseClick}
         >
           {flyinPanel}
+          {copy.ingredientsFlyoutBoilerplateOne && (
+            <Paragraph className={styles.descriptionCopy} theme={currentTheme}>
+              {copy.ingredientsFlyoutBoilerplateOne}
+            </Paragraph>
+          )}
+          {copy.ingredientsFlyoutBoilerplateTwo && (
+            <Paragraph className={styles.descriptionCopy} theme={currentTheme}>
+              {copy.ingredientsFlyoutBoilerplateTwo}
+            </Paragraph>
+          )}
         </FlyinPanel>
       )}
     </div>
@@ -254,6 +264,8 @@ ProductDetailBody.propTypes = {
         title: PropTypes.string,
       }),
     }),
+    ingredientsFlyoutBoilerplateOne: PropTypes.string,
+    ingredientsFlyoutBoilerplateTwo: PropTypes.string,
     size: PropTypes.shape({
       singular: PropTypes.string,
       plural: PropTypes.string,
@@ -275,6 +287,8 @@ ProductDetailBody.defaultProps = {
         title: undefined,
       },
     },
+    ingredientsFlyoutBoilerplateOne: undefined,
+    ingredientsFlyoutBoilerplateTwo: undefined,
     size: {
       singular: undefined,
       plural: undefined,


### PR DESCRIPTION
**Ticket**
https://aesoponline.atlassian.net/browse/CON-188

Added both flyout paragraphs as props through the updated copy to be rendered in the ProductDetailBody.js component.

**Screenshots**

Before [No Paragraphs]

![image](https://user-images.githubusercontent.com/42990483/113788456-4d18a180-9780-11eb-82bd-6446c94a1ec3.png)



After [Both Boilerplate Paragraphs]

![image](https://user-images.githubusercontent.com/42990483/113788343-0dea5080-9780-11eb-8606-fe1a6588c50e.png)

![image](https://user-images.githubusercontent.com/42990483/113788388-278b9800-9780-11eb-9acc-c54d4e53fb62.png)

![image](https://user-images.githubusercontent.com/42990483/113788401-2f4b3c80-9780-11eb-9726-a05b0a843ccc.png)
