### PR TITLE
Typescript: add shared component types

### DIFF
--- a/src/types/Component.types.ts
+++ b/src/types/Component.types.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import type { ReactElement, ReactNode } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DefaultReactComponentReturn = ReactElement<any, any> | null;
+type PropsWithChildren<P> = P & { children?: ReactNode };
+
+type ComponentWithChildren<P = {}> = (
+  props: PropsWithChildren<P>,
+) => DefaultReactComponentReturn;
+type ComponentWithoutChildren<P = {}> = (
+  props: P,
+) => DefaultReactComponentReturn;
+
+export { ComponentWithChildren, ComponentWithoutChildren };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,7 @@
+export type {
+  ComponentWithChildren,
+  ComponentWithoutChildren,
+} from './Component.types';
 export type { Product } from './Product.types';
 export type { Themes } from './Themes.types';
 export type { Variant } from './Variant.types';


### PR DESCRIPTION
Moving away from `React.FC` (refer to discussion [here](https://github.com/aesop/aesop-gel/pull/397#discussion_r614417432)) we thought it would be handy to create our types instead of manually needing to specify the return type for components (which would almost always be the same).

I created 2 new types: `ComponentWithChildren` and `ComponentWithoutChildren` and migrated Transition to use `ComponentWithChildren` to demo it.

Any feedback is appreciated 😃 