### PR TITLE
Integrate test reporter from Quality

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,18 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Fetch Quality test reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+
       - name: Test
-        run: npm run test
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: |
+          ./cc-test-reporter before-build
+          npm run test
+          ./cc-test-reporter after-build
 
       - name: Build for Release
         run: npm run release


### PR DESCRIPTION
This is to upload our coverage reports to CC Quality.

The successful build has uploaded the report as seen below at this [url](https://codeclimate.com/repos/6082153d47d59401b600bf71/settings/test_reporter)
![image](https://user-images.githubusercontent.com/33766083/115808193-63378a80-a42d-11eb-8886-b6891efe1983.png)
