### PR TITLE
Set value for commit hash and branch name for CC Quality

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,10 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Store branch name
+        run: |
+          echo "BRANCH_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Install
         run: npm ci
 
@@ -40,6 +44,8 @@ jobs:
       - name: Test
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          GIT_COMMIT_SHA: ${{ github.sha }}
+          GIT_BRANCH: ${{ env.BRANCH_NAME }}
         run: |
           ./cc-test-reporter before-build
           npm run test


### PR DESCRIPTION
GH doesn't expose the branch name and commit hash as env vars so it needs to be done manually.

#### Result from [coverage reports on CC Quality](https://codeclimate.com/repos/6082153d47d59401b600bf71/settings/test_reporter)
![image](https://user-images.githubusercontent.com/33766083/116022375-6c269700-a68d-11eb-898e-8be5fcfb9e7b.png)

#### Adds checks on test coverage for PRs
![image](https://user-images.githubusercontent.com/33766083/116022564-c3c50280-a68d-11eb-9292-baf677161800.png)
