### PR TITLE
Update `SectionHeading` type API

### DIFF
--- a/dist/components/SectionHeading/index.d.ts
+++ b/dist/components/SectionHeading/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactNode, ReactElement } from 'react';
 import { T as Themes } from '../../sharedChunks/Themes.types';
 
 declare type SectionHeadingProps = {
@@ -16,7 +16,7 @@ declare type SectionHeadingProps = {
     isOffsetPageHeading?: boolean;
     isHeroHeading?: boolean;
     isPageHeading?: boolean;
-    subHeading?: string;
+    subHeading?: ReactNode;
     theme?: Themes;
     titleFont?: 'Suisse' | 'Zapf';
 };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1482,7 +1482,7 @@ declare type SectionHeadingProps = {
     isOffsetPageHeading?: boolean;
     isHeroHeading?: boolean;
     isPageHeading?: boolean;
-    subHeading?: string;
+    subHeading?: ReactNode;
     theme?: Themes;
     titleFont?: 'Suisse' | 'Zapf';
 };

--- a/src/components/SectionHeading/SectionHeading.types.ts
+++ b/src/components/SectionHeading/SectionHeading.types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import type { Themes } from '~/types';
 
 type SectionHeadingProps = {
@@ -15,7 +17,7 @@ type SectionHeadingProps = {
   isOffsetPageHeading?: boolean;
   isHeroHeading?: boolean;
   isPageHeading?: boolean;
-  subHeading?: string;
+  subHeading?: ReactNode;
   theme?: Themes;
   titleFont?: 'Suisse' | 'Zapf';
 };


### PR DESCRIPTION
This PR updates the `subHeading` prop in the `SectionHeading` component to meet the requirements of https://github.com/aesop/aesop-web-ui/blob/develop/src/app/components-custom/contentful/Slices/PageTitle/PageTitle.js#L16