### PR TITLE
Chore/collaps dist diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Generated Files
+dist/* linguist-generated=true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33766083/126916383-ddf81d07-a6c5-40b5-bac7-bb65b3565828.png)

This PR adds a `.gitattributes` file to collapse the diffs of our dist files as recommended in [this](https://medium.com/@clarkbw/managing-generated-files-in-github-1f1989c09dfd) article.

The files will still be there but at least collapsed to reduce clutter and space used in the PR. This is what they will look like 
![image](https://user-images.githubusercontent.com/33766083/126917607-69555de6-8b30-471e-952e-d6545070ab9f.png)
