### PR TITLE
feat: pass other props to button html

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonRef(
     title,
     type = 'button',
     theme = 'dark',
+    ...otherProps
   },
   ref,
 ) {
@@ -42,6 +43,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonRef(
       tabIndex={tabIndex}
       title={title}
       type={type}
+      {...otherProps}
     >
       {children}
     </button>


### PR DESCRIPTION
I was trying to assign `aria-expanded` to Button and found that nothing was happening. This change allows passing additional props to Button which will then be passed to the underlying <button>.