### PR TITLE
Create personal account info summary comp

### DIFF
--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.fixture.ts
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.fixture.ts
@@ -1,0 +1,21 @@
+const PersonalInfoSummaryFixture = {
+  prefixOptions: [
+    { value: '', text: '' },
+    { value: 'ms', text: 'Ms' },
+    { value: 'mr', text: 'Mr' },
+    { value: 'mrs', text: 'Mrs' },
+    { value: 'dr', text: 'Dr' },
+    { value: 'miss', text: 'Miss' },
+    { value: 'mx', text: 'Mx' },
+  ],
+  userDetails: {
+    suffix: 'Esquire',
+    prefix: 'mr',
+    firstName: 'Bruce',
+    lastName: 'Kent',
+    dateOfBirth: '10/12/1921',
+    email: 'beevus@cornholio.com',
+  },
+};
+
+export { PersonalInfoSummaryFixture };

--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.module.css
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.module.css
@@ -1,0 +1,18 @@
+@import 'styles/index';
+
+.base {
+  font-family: "Suisse Regular", sans-serif;
+  font-size: rem(20px);
+
+  @media (--viewport-lg) {
+    font-size: rem(24px);
+  }
+
+  &.dark {
+    color: var(--color-dark-copy);
+  }
+
+  &.light {
+    color: var(--color-light-copy);
+  }
+}

--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.spec.tsx
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PersonalInfoSummary } from './PersonalInfoSummary';
+import * as utils from './utils/utils';
+import { PersonalInfoSummaryFixture } from './PersonalInfoSummary.fixture';
+
+const mockPrefix = 'Dr';
+const { userDetails, prefixOptions } = PersonalInfoSummaryFixture;
+
+describe('<PersonalInfoSummary />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(utils, 'matchCodeToText').mockImplementation(() => mockPrefix);
+  });
+
+  it('should not render elements if the userDetails are missing', () => {
+    render(<PersonalInfoSummary />);
+    const component = screen.queryByTestId('personal-info-summary');
+
+    expect(component).not.toBeInTheDocument();
+  });
+
+  it(`should correctly call matchCodeToText`, () => {
+    render(
+      <PersonalInfoSummary
+        prefixOptions={prefixOptions}
+        userDetails={userDetails}
+      />,
+    );
+
+    expect(utils.matchCodeToText).toHaveBeenCalledWith(
+      prefixOptions,
+      userDetails.prefix,
+    );
+  });
+
+  it(`should render all the available fields`, () => {
+    const { firstName, lastName, dateOfBirth, email, suffix } = userDetails;
+    render(<PersonalInfoSummary userDetails={userDetails} />);
+
+    expect(
+      screen.getByText(`${mockPrefix} ${firstName} ${lastName} ${suffix}`),
+    ).toBeInTheDocument();
+    expect(screen.getByText(email)).toBeInTheDocument();
+    expect(screen.getByText(dateOfBirth)).toBeInTheDocument();
+  });
+
+  it(`should reverse the order of the name if shouldSwapFullNameOrder is true`, () => {
+    const { firstName, lastName, suffix } = userDetails;
+    render(
+      <PersonalInfoSummary
+        shouldSwapFullNameOrder={true}
+        userDetails={userDetails}
+      />,
+    );
+
+    expect(
+      screen.getByText(`${mockPrefix} ${lastName} ${firstName} ${suffix}`),
+    ).toBeInTheDocument();
+  });
+
+  it(`should hide the prefix if shouldShowPrefix is false`, () => {
+    const { firstName, lastName, suffix } = userDetails;
+    render(
+      <PersonalInfoSummary
+        shouldShowPrefix={false}
+        userDetails={userDetails}
+      />,
+    );
+
+    expect(
+      screen.getByText(`${firstName} ${lastName} ${suffix}`),
+    ).toBeInTheDocument();
+  });
+
+  it(`should render an empty suffix if one is not provided`, () => {
+    const { firstName, lastName } = userDetails;
+    render(
+      <PersonalInfoSummary
+        userDetails={{ ...userDetails, suffix: undefined }}
+      />,
+    );
+
+    expect(
+      screen.getByText(`${mockPrefix} ${firstName} ${lastName}`),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.stories.mdx
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.stories.mdx
@@ -1,0 +1,87 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import * as knobs from '@storybook/addon-knobs';
+import { StorybookGridOverlay } from '~.storybook/components';
+import { PersonalInfoSummary } from './PersonalInfoSummary';
+import { PersonalInfoSummaryFixture } from './PersonalInfoSummary.fixture';
+
+<Meta title="Components/PersonalInfoSummary" component={PersonalInfoSummary} />
+
+# PersonalInfoSummary
+
+<Canvas>
+  <Story name="Base component">
+    {(() => {
+      const theme = knobs.select(
+        'theme',
+        ['dark', 'light'],
+        'dark',
+        'Presentation',
+      );
+      const implementation = {
+        gridOverlay: {
+          isActive: knobs.boolean('Show grid overlay', false, 'Implementation'),
+          hasInvertedColours: knobs.boolean(
+            'Invert grid overlay colours',
+            false,
+            'Implementation',
+          ),
+        },
+      };
+      return (
+        <>
+          <PersonalInfoSummary
+            theme={theme}
+            prefixOptions={PersonalInfoSummaryFixture.prefixOptions}
+            shouldShowPrefix={knobs.boolean(
+              'shouldShowPrefix',
+              true,
+              'Content',
+            )}
+            shouldSwapFullNameOrder={knobs.boolean(
+              'shouldSwapFullNameOrder',
+              false,
+              'Content',
+            )}
+            userDetails={{
+              suffix: knobs.text(
+                'suffix',
+                PersonalInfoSummaryFixture.userDetails.suffix,
+                'Content',
+              ),
+              prefix: knobs.text(
+                'prefix',
+                PersonalInfoSummaryFixture.userDetails.prefix,
+                'Content',
+              ),
+              firstName: knobs.text(
+                'firstName',
+                PersonalInfoSummaryFixture.userDetails.firstName,
+                'Content',
+              ),
+              lastName: knobs.text(
+                'lastName',
+                PersonalInfoSummaryFixture.userDetails.lastName,
+                'Content',
+              ),
+              dateOfBirth: knobs.text(
+                'dateOfBirth',
+                PersonalInfoSummaryFixture.userDetails.dateOfBirth,
+                'Content',
+              ),
+              email: knobs.text(
+                'email',
+                PersonalInfoSummaryFixture.userDetails.email,
+                'Content',
+              ),
+            }}
+          />
+          <StorybookGridOverlay {...implementation.gridOverlay} />
+        </>
+      );
+    })()}
+  </Story>
+</Canvas>
+
+## API
+
+<ArgsTable of={PersonalInfoSummary} />

--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.tsx
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import cx from 'classnames';
+import { useThemeContext } from '~/contexts';
+import { matchCodeToText } from './utils/utils';
+import type { PersonalInfoSummaryType } from './PersonalInfoSummary.types';
+import styles from './PersonalInfoSummary.module.css';
+
+const PersonalInfoSummary: PersonalInfoSummaryType = ({
+  className,
+  prefixOptions = [],
+  shouldShowPrefix = true,
+  shouldSwapFullNameOrder = false,
+  theme,
+  userDetails,
+}) => {
+  const currentTheme = useThemeContext(theme, 'dark');
+
+  if (!userDetails) {
+    return null;
+  }
+
+  const classSet = cx(styles.base, styles[currentTheme], className);
+
+  const prefix = shouldShowPrefix
+    ? matchCodeToText(prefixOptions, userDetails.prefix)
+    : '';
+
+  const fullName = shouldSwapFullNameOrder
+    ? `${userDetails.lastName} ${userDetails.firstName}`
+    : `${userDetails.firstName} ${userDetails.lastName}`;
+
+  const suffix = userDetails.suffix ?? '';
+
+  return (
+    <div className={classSet} data-testid="personal-info-summary">
+      <div>{`${prefix} ${fullName} ${suffix}`}</div>
+      <div>{userDetails.email}</div>
+      <div>{userDetails.dateOfBirth}</div>
+    </div>
+  );
+};
+
+export { PersonalInfoSummary };

--- a/src/components/PersonalInfoSummary/PersonalInfoSummary.types.ts
+++ b/src/components/PersonalInfoSummary/PersonalInfoSummary.types.ts
@@ -1,0 +1,22 @@
+import type { VFC } from 'react';
+import type { Themes } from '~/types';
+
+type PersonalInfoSummaryProps = {
+  className?: string;
+  theme?: Themes;
+  prefixOptions?: { value: string; text: string }[];
+  shouldShowPrefix?: boolean;
+  shouldSwapFullNameOrder?: boolean;
+  userDetails?: {
+    suffix?: string;
+    prefix?: string;
+    firstName?: string;
+    lastName?: string;
+    dateOfBirth?: string;
+    email?: string;
+  };
+};
+
+type PersonalInfoSummaryType = VFC<PersonalInfoSummaryProps>;
+
+export type { PersonalInfoSummaryType };

--- a/src/components/PersonalInfoSummary/index.ts
+++ b/src/components/PersonalInfoSummary/index.ts
@@ -1,0 +1,3 @@
+import { PersonalInfoSummary } from './PersonalInfoSummary';
+
+export { PersonalInfoSummary };

--- a/src/components/PersonalInfoSummary/utils/utils.spec.ts
+++ b/src/components/PersonalInfoSummary/utils/utils.spec.ts
@@ -1,0 +1,18 @@
+import { matchCodeToText } from './utils';
+
+describe(`PersonalInfoSummary - utils`, () => {
+  describe(`matchCodeToText`, () => {
+    const options = [
+      { value: 'cap', text: 'Captain' },
+      { value: 'dunk', text: 'Dunkey' },
+    ];
+
+    it(`should return the text if the value specified is found`, () => {
+      expect(matchCodeToText(options, 'cap')).toEqual('Captain');
+    });
+
+    it(`should return an empty string if the value specified is not found`, () => {
+      expect(matchCodeToText(options, 'don')).toEqual('');
+    });
+  });
+});

--- a/src/components/PersonalInfoSummary/utils/utils.ts
+++ b/src/components/PersonalInfoSummary/utils/utils.ts
@@ -1,0 +1,6 @@
+export const matchCodeToText = (
+  options: { value: string; text: string }[],
+  code: string,
+): string => {
+  return options.find((x) => x.value === code)?.text ?? '';
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export { NavigationBar } from './NavigationBar';
 export { NotificationModal } from './NotificationModal';
 export { Overlay } from './Overlay';
 export { Paragraph, P, ParagraphSet } from './Paragraph';
+export { PersonalInfoSummary } from './PersonalInfoSummary';
 export { Podium } from './Podium';
 export { ProductCommerce } from './ProductCommerce';
 export { ProductExtract } from './ProductExtract';

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   P,
   Paragraph,
   ParagraphSet,
+  PersonalInfoSummary,
   Podium,
   ProductAccordion,
   ProductCommerce,


### PR DESCRIPTION
The purpose is to move out [this](https://github.com/aesop/aesop-web-ui/blob/develop/src/app/components-custom/account/information/AccountInfoPersonal.js#L49-L80) component so it can be used in aesop-com.

#### Todo
- [x] Tests
- [x] Export the component so it can be consumed