### PR TITLE
Component enhancements

### DIFF
--- a/src/components/Audio/__snapshots__/Audio.spec.tsx.snap
+++ b/src/components/Audio/__snapshots__/Audio.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`<Audio /> should render base component correctly 1`] = `
       class="waveContainer"
     >
       <span
-        class="base isLoading medium dark loading"
+        class="base isLoading center medium dark loading"
         data-testid="data-testid-loading"
         role="status"
       >

--- a/src/components/BynderWidget/__snapshots__/BynderWidget.spec.tsx.snap
+++ b/src/components/BynderWidget/__snapshots__/BynderWidget.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`<BynderWidget /> should render base component correctly 1`] = `
       heading
     </h3>
     <span
-      class="base isLoading medium dark"
+      class="base isLoading center medium dark"
       data-testid="data-testid-loading"
       role="status"
     >

--- a/src/components/GoogleMap/__snapshots__/GoogleMap.spec.js.snap
+++ b/src/components/GoogleMap/__snapshots__/GoogleMap.spec.js.snap
@@ -9,7 +9,7 @@ exports[`<GoogleMap /> should render base component correctly 1`] = `
       class="wrapper"
     >
       <span
-        class="base medium dark loading"
+        class="base center medium dark loading"
         data-testid="data-testid-loading"
         role="status"
       />

--- a/src/components/Hyperlink/Hyperlink.stories.mdx
+++ b/src/components/Hyperlink/Hyperlink.stories.mdx
@@ -9,8 +9,8 @@ import { Hyperlink } from './Hyperlink';
 <Canvas>
   <Story name="Base component">
     <Hyperlink
-      style={knobs.select(
-        'style',
+      kind={knobs.select(
+        'kind',
         [
           'External Button Link',
           'External No Icon Button Link',

--- a/src/components/Hyperlink/Hyperlink.tsx
+++ b/src/components/Hyperlink/Hyperlink.tsx
@@ -20,8 +20,9 @@ const Hyperlink = forwardRef<HTMLAnchorElement, HyperlinkProps>(
       hasTargetInNewWindow = false,
       isAlternate,
       isDownload,
+      kind,
       onClick,
-      style = 'Internal No Icon Link',
+      style,
       tabIndex,
       textAlign = 'left',
       theme = 'dark',
@@ -30,9 +31,10 @@ const Hyperlink = forwardRef<HTMLAnchorElement, HyperlinkProps>(
     },
     ref,
   ) => {
-    const isInline = checkIsInlineFromStyle(style);
-    const isExternal = checkIsExternalFromStyle(style);
-    const hasIcon = hasIconFromStyle(style);
+    const linkStyle = style || kind || 'Internal No Icon Link';
+    const isInline = checkIsInlineFromStyle(linkStyle);
+    const isExternal = checkIsExternalFromStyle(linkStyle);
+    const hasIcon = hasIconFromStyle(linkStyle);
     const target = getTargetType(hasTargetInNewWindow);
     const classSet = cx(
       styles.base,

--- a/src/components/Hyperlink/Hyperlink.types.ts
+++ b/src/components/Hyperlink/Hyperlink.types.ts
@@ -20,7 +20,9 @@ type HyperlinkProps = {
   id?: string;
   isAlternate?: boolean;
   isDownload?: boolean;
+  kind?: LinkStyle;
   onClick?: (event: MouseEvent) => void;
+  /** @deprecated use `kind` instead */
   style?: LinkStyle;
   tabIndex?: number;
   textAlign?: TextAlign;

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -10,8 +10,18 @@
   display: flex;
   width: 100%;
   align-items: center;
-  justify-content: center;
   pointer-events: none;
+}
+
+.start {
+  justify-content: start;
+}
+.center {
+  justify-content: center;
+}
+
+.end {
+  justify-content: end;
 }
 
 .small {

--- a/src/components/Loading/Loading.stories.mdx
+++ b/src/components/Loading/Loading.stories.mdx
@@ -10,6 +10,12 @@ import { Loading } from './Loading';
 <Canvas>
   <Story name="Base component">
     {(() => {
+      const align = knobs.select(
+        'align',
+        ['start', 'center', 'end'],
+        'center',
+        'Presentation',
+      );
       const isLoading = knobs.boolean('isLoading', true, 'Presentation');
       const screenReaderText = knobs.text(
         'screenReaderText',
@@ -46,6 +52,7 @@ import { Loading } from './Loading';
       return (
         <>
           <Loading
+            align={align}
             isLoading={isLoading}
             screenReaderText={screenReaderText}
             shouldFillSpace={shouldFillSpace}

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -5,6 +5,7 @@ import type { LoadingType } from './Loading.types';
 import styles from './Loading.module.css';
 
 const Loading: LoadingType = ({
+  align = 'center',
   className,
   isLoading,
   screenReaderText,
@@ -20,6 +21,7 @@ const Loading: LoadingType = ({
       [styles.isLoading]: isLoading,
       [styles.fullSize]: shouldFillSpace,
     },
+    styles[align],
     styles[size],
     styles[currentTheme],
     className,

--- a/src/components/Loading/Loading.types.ts
+++ b/src/components/Loading/Loading.types.ts
@@ -3,6 +3,7 @@ import type { ComponentWithoutChildren, Themes } from '~/types';
 type LoadingSizes = 'small' | 'medium' | 'large';
 
 type LoadingProps = {
+  align?: 'start' | 'center' | 'end';
   className?: string;
   isLoading: boolean;
   screenReaderText?: string;

--- a/src/components/Loading/__snapshots__/Loading.spec.tsx.snap
+++ b/src/components/Loading/__snapshots__/Loading.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Loading /> should render base component correctly 1`] = `
 <div>
   <span
-    class="base isLoading medium dark"
+    class="base isLoading center medium dark"
     data-testid="data-testid-loading"
     role="status"
   >


### PR DESCRIPTION
### Changes

1. **HyperLink**: deprecate the `style` prop because it violates an eslint [rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md) requiring consuming code to disable it. Add a new prop to offer the same functionality.

![HyperLink](https://user-images.githubusercontent.com/33766083/131586722-3ffb7558-b455-4cd4-b305-7063204c134d.gif)


2. **Loading**: add `align` prop to allow position the loading dots

![Loading](https://user-images.githubusercontent.com/33766083/131586732-319d57e6-43ee-4e1c-a7bc-bff7852f7fcc.gif)
