### PR TITLE
fix(DynamicForm): export schema type

### DIFF
--- a/src/compositions/DynamicForm/DynamicForm.types.ts
+++ b/src/compositions/DynamicForm/DynamicForm.types.ts
@@ -43,12 +43,14 @@ type FieldSchema = {
 
 type FormFieldsRow = FieldSchema[];
 
+export type FormSchema = FormFieldsRow[];
+
 export type DynamicFormProps = {
   children?: ReactNode;
   className?: string;
   defaultValues?: Record<string, string>;
   formName?: string;
-  formSchema?: FormFieldsRow[];
+  formSchema?: FormSchema;
   onSubmit: (formData: Record<string, string>) => void;
   theme?: Themes;
   validationMode?: Mode;

--- a/src/compositions/DynamicForm/index.ts
+++ b/src/compositions/DynamicForm/index.ts
@@ -1,3 +1,5 @@
 import { DynamicForm } from './DynamicForm';
+import type { FormSchema } from './DynamicForm.types';
 
+export type { FormSchema };
 export { DynamicForm };


### PR DESCRIPTION
Exporting the schema type to help consumers get type validation instead of using `any`.