### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Source code owners
+/src/ @hassanraza0054 @kevin-ho87 @MkMan @zack76


### PR DESCRIPTION
This change will automatically add the current front end devs to any PR created that changes files inside `/src/`