### PR TITLE
[Feature/Nav]: Add dataTestRefs for desktop view

### DIFF
--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionImage/CollectionImage.tsx
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionImage/CollectionImage.tsx
@@ -3,11 +3,11 @@ import { Image } from '~/components/Image';
 import type { CollectionImageType } from './CollectionImage.types';
 import styles from './CollectionImage.module.css';
 
-const CollectionImage: CollectionImageType = ({ altText, sizes }) => {
+const CollectionImage: CollectionImageType = ({ altText, sizes, dataTestRef }) => {
   if (!sizes) return null;
 
   return (
-    <div className={styles.base}>
+    <div className={styles.base} data-test-ref={dataTestRef}>
       <Image
         altText={altText}
         className={styles.image}

--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionImage/CollectionImage.types.ts
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionImage/CollectionImage.types.ts
@@ -2,6 +2,7 @@ import type { ComponentWithoutChildren } from '~/types';
 
 type CollectionImageProps = {
   altText?: string;
+  dataTestRef?: string;
   sizes?: {
     medium?: string;
     large?: string;

--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionLayout/CollectionLayout.tsx
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionLayout/CollectionLayout.tsx
@@ -32,30 +32,54 @@ const CollectionLayout: CollectionLayoutType = ({
     <>
       <div className={styles.collectionsWrapper}>
         <CollectionList
+          dataTestRef={`NAV_${currentId.toUpperCase()}_TLC`}
           heading={topLevelCollectionLabel}
           items={topLevelCollections}
         />
 
         {type === 'read-collection' && (
-          <CollectionList eyebrow={articlesListHeading} items={articles} />
+          <CollectionList
+            dataTestRef={`NAV_${currentId.toUpperCase()}_TLC_READ`}
+            eyebrow={articlesListHeading}
+            items={articles}
+          />
         )}
       </div>
 
       <div className={styles.supplementary}>
         <div className={styles.nestedCollectionsWrapper}>
           <div className={styles.nestedCollections}>
-            {nestedCollections.filter(Boolean).map(({ label, id, items }) => (
-              <CollectionList heading={label} items={items} key={id} />
-            ))}
+            {nestedCollections
+              .filter(Boolean)
+              .map(({ label, id, items }, index) => (
+                <CollectionList
+                  dataTestRef={`NAV_${currentId.toUpperCase()}_NECO_${
+                    index + 1
+                  }`}
+                  heading={label}
+                  items={items}
+                  key={id}
+                />
+              ))}
 
             {!!taxonomyOfDesignElement && (
-              <CollectionList items={[taxonomyOfDesignElement]} />
+              <CollectionList
+                dataTestRef={`NAV_${currentId.toUpperCase()}_NECO_TOD`}
+                items={[taxonomyOfDesignElement]}
+              />
             )}
           </div>
 
           <div className={styles.notableNestedCollections}>
-            {notableNestedCollections.map(({ label, items, id }) => (
-              <CollectionList heading={label} items={items} key={id} />
+            {notableNestedCollections.map(({ label, items, id }, index) => (
+              <CollectionList
+                dataTestRef={`NAV_${currentId.toUpperCase()}_NONECO_${
+                  index + 1
+                }`}
+                heading={label}
+                items={items}
+                key={id}
+              />
             ))}
           </div>
         </div>
@@ -64,6 +88,7 @@ const CollectionLayout: CollectionLayoutType = ({
           <div className={styles.promotion}>
             <PromotionCard
               {...promotion}
+              dataTestRef={`NAV_${currentId.toUpperCase()}_PROMO_CARD`}
               isFlush={true}
               isVisible={isOpen && activeCollectionId === currentId}
             />
@@ -71,7 +96,10 @@ const CollectionLayout: CollectionLayoutType = ({
         )}
       </div>
 
-      <CollectionImage {...image} />
+      <CollectionImage
+        {...image}
+        dataTestRef={`NAV_${currentId.toUpperCase()}_COLLECTION_IMAGE`}
+      />
     </>
   );
 };

--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.tsx
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.tsx
@@ -6,7 +6,7 @@ import { CollectionItem } from '../CollectionItem';
 import type { CollectionListType } from './CollectionList.types';
 import styles from './CollectionList.module.css';
 
-const CollectionList: CollectionListType = ({ heading, items, eyebrow }) => {
+const CollectionList: CollectionListType = ({ heading, items, eyebrow, dataTestRef}) => {
   const { isActive } = useMenuItemContext();
   const currentTheme = useThemeContext(undefined, 'dark');
 
@@ -15,12 +15,12 @@ const CollectionList: CollectionListType = ({ heading, items, eyebrow }) => {
   return (
     <>
       {eyebrow && (
-        <small className={cx(styles.eyebrow, styles.small)}>{eyebrow}</small>
+        <small className={cx(styles.eyebrow, styles.small)} data-test-ref={`${dataTestRef}_EYEBROW`}>{eyebrow}</small>
       )}
 
-      {heading && <strong className={styles.heading}>{heading}</strong>}
+      {heading && <strong className={styles.heading} data-test-ref={`${dataTestRef}_HEADING`}>{heading}</strong>}
 
-      <ul aria-hidden={!isActive} aria-label="submenu" className={listClassSet}>
+      <ul aria-hidden={!isActive} aria-label="submenu" className={listClassSet} data-test-ref={`${dataTestRef}_ITEMLIST`}>
         {items.map((itemProps) => (
           <CollectionItem {...itemProps} key={itemProps.id} />
         ))}

--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.types.ts
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.types.ts
@@ -5,6 +5,7 @@ import {
 } from '~/components/GlobalNavigation/GlobalNavigation.types';
 
 type CollectionListProps = {
+  dataTestRef?: string;
   eyebrow?: string;
   heading?: string;
   items: (Article | Link)[];

--- a/src/components/GlobalNavigation/components/PromotionCard/PromotionCard.tsx
+++ b/src/components/GlobalNavigation/components/PromotionCard/PromotionCard.tsx
@@ -17,6 +17,7 @@ const PromotionCard: PromotionCardType = ({
   isFlush = false,
   isVisible = true,
   label,
+  dataTestRef,
   title,
   url,
 }) => {
@@ -37,6 +38,7 @@ const PromotionCard: PromotionCardType = ({
   return (
     <Hyperlink
       className={classSet}
+      dataTestRef={dataTestRef}
       tabIndex={!isVisible ? -1 : null}
       theme={currentTheme}
       title={title}

--- a/src/components/GlobalNavigation/components/PromotionCard/PromotionCard.types.ts
+++ b/src/components/GlobalNavigation/components/PromotionCard/PromotionCard.types.ts
@@ -6,6 +6,7 @@ import type {
 
 type PromotionCardProps = Clickable & {
   className?: string;
+  dataTestRef?: string;
   heading: string;
   isFlush?: boolean;
   isVisible?: boolean;


### PR DESCRIPTION
As per QA requirements, added data-test-refs for highlighted regions in new Nav for Desktop view.

https://lucid.app/lucidchart/invitations/accept/inv_9be02fa5-a747-4e4d-a0a1-95f90395dc32


**Changes Video**
https://user-images.githubusercontent.com/42990483/133234043-646f46f5-daad-4f14-bda6-e9d756fe27e2.mov

**Identifiers used**
TLC => Top Level Collection
NECO => Nested Collection
NONECO => Notable Nested Collection
TOD => Taxonomy Of Design

With **Read**, I chose to identify the second ul, i.e. the **Read-Collection**, by adding the suffix "-READ" ahead of the TLC naming. This is to accomodate the implementation in code, where its seen that a second ul only comes in the first column of the nav panel if it is a **Read-Collection** (Screenshot below for reference).

![image](https://user-images.githubusercontent.com/42990483/133239543-860eee3a-eefa-4217-b931-739cd3bba58b.png)

Keen to get feedback. Chose data-test-ref names with the following assumptions:-

1. ID's will remain most consistent throughout development of the nav, making them great candidates to construct the data test ref strings.
2. Naming scheme (i.e. acronyms/identifiers chosen above) are self-explanatory based on the understanding of first column, second column and third column items in the Nav hosting **Top Level Collections**, **Nested Collections** & **Notable Nested Collections** respectively.