### PR TITLE
refactor(DynamicForm): improve TS defintion

### DIFF
--- a/src/compositions/DynamicForm/DynamicForm.types.ts
+++ b/src/compositions/DynamicForm/DynamicForm.types.ts
@@ -4,10 +4,13 @@ import type { SelectProps } from '~/components/Select/Select.types';
 import type { TextInputV2Props } from '~/components/TextInputV2/TextInputV2.types';
 import type { Themes } from '~/types';
 import type { FieldValidation } from './validators/validators.types';
-import type { AvailableFormFieldTypes } from './wrappers';
 
-type FieldSchema = {
-  /** An initial value for the field. The value in `defaultValues` prop for the same field will take presedence */
+type CheckBox = { type: 'Checkbox' };
+type Select = { type: 'Select'; options: SelectProps['options'] };
+type TextField = { type: 'TextField'; subtype: TextInputV2Props['type'] };
+
+export type FieldSchema = {
+  /** An initial value for the field. The value in `defaultValues` prop for the same field will take precedence */
   defaultValue?: string;
 
   /** The field's HTML id attribute */
@@ -19,27 +22,18 @@ type FieldSchema = {
   /** An identifier of the field to the form */
   name: string;
 
-  /** Needed for the Select field type, passed on as the drop down options */
-  options?: SelectProps['options'];
-
   /** Contains properties relating to the field's appearance */
   styling?: {
     /** Corresponds to the css `flex` property. Can be a value of 1, 2 or 3 */
     flex?: number;
   };
 
-  /** Used as the type for the TextField field type */
-  subtype?: TextInputV2Props['type'];
-
   /** Passed to fields as `dataTestRef` */
   testRef?: string;
 
-  /** Defines the field type */
-  type: AvailableFormFieldTypes;
-
   /** Contains validation rules for the form field */
   validation?: FieldValidation;
-};
+} & (CheckBox | Select | TextField);
 
 type FormFieldsRow = FieldSchema[];
 

--- a/src/compositions/DynamicForm/FormField.tsx
+++ b/src/compositions/DynamicForm/FormField.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { componentMap } from './wrappers';
+import { getValidationRules } from './validators/validators';
+import type { VFC } from 'react';
+import type { FieldSchema, DynamicFormProps } from './DynamicForm.types';
+
+type FormFieldProps = FieldSchema & {
+  formFieldClassSet: string;
+  theme: DynamicFormProps['theme'];
+  defaultValues: DynamicFormProps['defaultValues'];
+};
+
+export const FormField: VFC<FormFieldProps> = ({
+  defaultValues,
+  formFieldClassSet,
+  theme,
+  ...fieldValues
+}) => {
+  const { control, errors, getValues } = useFormContext();
+  const {
+    defaultValue: defaultValueFromSchema,
+    id,
+    label,
+    name,
+    testRef,
+    validation,
+    ...fieldSpecificValues
+  } = fieldValues;
+  const type = fieldSpecificValues.type;
+  const InputField = componentMap[type];
+
+  if (!InputField) {
+    // eslint-disable-next-line no-console
+    console.warn(`Field with type ${type} has no registered component`);
+    return null;
+  }
+
+  return (
+    <InputField
+      className={formFieldClassSet}
+      control={control}
+      dataTestRef={testRef}
+      defaultValue={defaultValues?.[name] || defaultValueFromSchema}
+      errorMessage={errors[name]?.message}
+      id={id}
+      key={name}
+      label={label}
+      name={name}
+      options={
+        fieldSpecificValues.type === 'Select'
+          ? fieldSpecificValues.options
+          : undefined
+      }
+      rules={getValidationRules(validation, type, getValues)}
+      subtype={
+        fieldSpecificValues.type === 'TextField'
+          ? fieldSpecificValues.subtype
+          : undefined
+      }
+      theme={theme}
+    />
+  );
+};

--- a/src/compositions/DynamicForm/index.ts
+++ b/src/compositions/DynamicForm/index.ts
@@ -1,5 +1,5 @@
 import { DynamicForm } from './DynamicForm';
-import type { FormSchema } from './DynamicForm.types';
+import type { FormSchema, FieldSchema } from './DynamicForm.types';
 
-export type { FormSchema };
+export type { FormSchema, FieldSchema };
 export { DynamicForm };


### PR DESCRIPTION
The main changes in this PR are:
- using [discriminated union type](https://basarat.gitbook.io/typescript/type-system/discriminated-unions#discriminated-union) to make the schema definition more robust and remove unnecessary optional modifier on properties
- moving some of the jsx out to a new component to keep files short and clear
- renaming some loop variables for clarity