### PR TITLE
chore(eslint): disable max lines/func in spec files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,8 @@
       },
       "rules": {
         "@typescript-eslint/no-explicit-any": "off",
-        "init-declarations": "off"
+        "init-declarations": "off",
+        "max-lines-per-function": "off"
       }
     },
     {


### PR DESCRIPTION
This is to disable the maximum lines per function rule in test files as the callback functions passed to `describe` and `it` will easily violate this.