### PR TITLE
Date selector fixes

### DIFF
--- a/src/components/DateSelector/DateSelector.module.css
+++ b/src/components/DateSelector/DateSelector.module.css
@@ -2,6 +2,7 @@
 
 .base {
   display: flex;
+  width: 100%;
   flex-direction: column;
 
   @media (--viewport-md) {

--- a/src/components/DateSelector/DateSelector.spec.tsx
+++ b/src/components/DateSelector/DateSelector.spec.tsx
@@ -36,7 +36,8 @@ describe('<DateSelector />', () => {
     userEvent.selectOptions(getDayDropDown(), ['01']);
 
     // month and year not selected => returns empty string
-    expect(onChange).toHaveBeenLastCalledWith('');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('');
   });
 
   it(`should update the day options when the year/month change`, () => {

--- a/src/components/DateSelector/DateSelector.stories.mdx
+++ b/src/components/DateSelector/DateSelector.stories.mdx
@@ -16,6 +16,7 @@ import { DateSelector } from './DateSelector';
         'dark',
         'Presentation',
       );
+      const isEnabled = knobs.boolean('isEnabled', true);
       const implementation = {
         gridOverlay: {
           isActive: knobs.boolean('Show grid overlay', false, 'Implementation'),
@@ -29,7 +30,11 @@ import { DateSelector } from './DateSelector';
       const onChange = (date) => console.log('Date is ', date);
       return (
         <>
-          <DateSelector theme={theme} onChange={onChange} />
+          <DateSelector
+            isEnabled={isEnabled}
+            theme={theme}
+            onChange={onChange}
+          />
           <StorybookGridOverlay {...implementation.gridOverlay} />
         </>
       );

--- a/src/components/DateSelector/DateSelector.tsx
+++ b/src/components/DateSelector/DateSelector.tsx
@@ -6,15 +6,16 @@ import {
   generateDayOptions,
   generateMonthOptions,
   generateYearOptions,
+  getMaxDaysInAMonth,
   splitIsoDate,
   useUpdateDayOptions,
-  useUpdateDayValue,
 } from './DateSelector.utils';
 import type { DatePortion, DateSelectorType } from './DateSelector.types';
 import styles from './DateSelector.module.css';
 
 const DateSelector: DateSelectorType = ({
   copy,
+  isEnabled = true,
   maxYears = 100,
   name = 'date-selector',
   onChange,
@@ -30,10 +31,16 @@ const DateSelector: DateSelectorType = ({
 
   const updateDate = useCallback(
     (portion: DatePortion, value: string) => {
-      const newDay = portion === 'day' ? value : day;
+      let newDay = portion === 'day' ? value : day;
       const newMonth = portion === 'month' ? value : month;
       const newYear = portion === 'year' ? value : year;
-      const isNewDateValid = !!newDay && !!newMonth && !!newYear;
+      const maxDaysInMonth = getMaxDaysInAMonth(newMonth, newYear);
+
+      const shouldResetDayValue = parseInt(newDay, 10) > maxDaysInMonth;
+      newDay = shouldResetDayValue ? '' : newDay;
+
+      const areAllSegmentsDefined = !!newDay && !!newMonth && !!newYear;
+      const isNewDateValid = areAllSegmentsDefined && !shouldResetDayValue;
 
       setDate(() => {
         const newDate = [newYear, newMonth, newDay].join('-');
@@ -45,12 +52,12 @@ const DateSelector: DateSelectorType = ({
   );
 
   useUpdateDayOptions(date, setDayOptions);
-  useUpdateDayValue(date, updateDate);
 
   return (
     <div className={classSet}>
       <Select
         className={cx(styles.dropDown)}
+        isEnabled={isEnabled}
         label={copy?.day ?? 'Day'}
         name={`${name}-day`}
         onChange={(event) => {
@@ -62,6 +69,7 @@ const DateSelector: DateSelectorType = ({
       />
       <Select
         className={cx(styles.dropDown)}
+        isEnabled={isEnabled}
         label={copy?.month ?? 'Month'}
         name={`${name}-month`}
         onChange={(event) => {
@@ -73,6 +81,7 @@ const DateSelector: DateSelectorType = ({
       />
       <Select
         className={cx(styles.dropDown)}
+        isEnabled={isEnabled}
         label={copy?.year ?? 'Year'}
         name={`${name}-year`}
         onChange={(event) => {

--- a/src/components/DateSelector/DateSelector.types.ts
+++ b/src/components/DateSelector/DateSelector.types.ts
@@ -11,6 +11,8 @@ type DateSelectorProps = {
     year?: string;
   };
 
+  isEnabled?: boolean;
+
   /** Maximum number of years to show in the year dropdown */
   maxYears?: number;
   name?: string;
@@ -25,4 +27,4 @@ type DateSelectorType = ComponentWithoutChildren<DateSelectorProps>;
 
 type DatePortion = 'day' | 'month' | 'year';
 
-export type { DateSelectorType, DatePortion };
+export type { DateSelectorProps, DateSelectorType, DatePortion };

--- a/src/components/DateSelector/DateSelector.utils.ts
+++ b/src/components/DateSelector/DateSelector.utils.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import type { SelectProps } from '~/components/Select/Select.types';
-import type { DatePortion } from './DateSelector.types';
 
 type SelectOptions = SelectProps['options'];
 
@@ -94,20 +93,6 @@ const useUpdateDayOptions = (
   }, [date, setDayOptions]);
 };
 
-const useUpdateDayValue = (
-  date: string,
-  updateDate: (portion: DatePortion, value: string) => void,
-): void => {
-  useEffect(() => {
-    const { day, month, year } = splitIsoDate(date);
-    const maxDaysInMonth = getMaxDaysInAMonth(month, year);
-
-    if (parseInt(day, 10) > maxDaysInMonth) {
-      updateDate('day', '');
-    }
-  }, [date, updateDate]);
-};
-
 export {
   generateDayOptions,
   generateMonthOptions,
@@ -115,5 +100,4 @@ export {
   getMaxDaysInAMonth,
   splitIsoDate,
   useUpdateDayOptions,
-  useUpdateDayValue,
 };


### PR DESCRIPTION
Changes:
- Allow the component to be disabled by adding the `isEnabled` prop
- Make the component take 100% width of the element its in
- Fix an issue where onChange was called twice when the currently selected day value was higher than the number of days in the current month