### PR TITLE
[Hyperlink] adding option to add data-test-id to Hyperlinks

### DIFF
--- a/src/components/GlobalNavigation/components/TabletView/components/CollectionItem/CollectionItem.tsx
+++ b/src/components/GlobalNavigation/components/TabletView/components/CollectionItem/CollectionItem.tsx
@@ -33,7 +33,12 @@ const CollectionItem: CollectionItemType = ({
   };
 
   return rest.type === 'link' ? (
-    <Hyperlink {...sharedProps} url={rest.url}>
+    <Hyperlink
+      dataTestId={id}
+      dataTestRef="CollectionItem"
+      {...sharedProps}
+      url={rest.url}
+    >
       <span className={compositionStyles.ornamentalHover}>{label}</span>
     </Hyperlink>
   ) : (

--- a/src/components/Hyperlink/Hyperlink.tsx
+++ b/src/components/Hyperlink/Hyperlink.tsx
@@ -16,6 +16,7 @@ const Hyperlink = forwardRef<HTMLAnchorElement, HyperlinkProps>(
     {
       children,
       className,
+      dataTestId,
       dataTestRef,
       hasTargetInNewWindow = false,
       isAlternate,
@@ -58,6 +59,7 @@ const Hyperlink = forwardRef<HTMLAnchorElement, HyperlinkProps>(
     return (
       <a
         className={classSet}
+        data-test-id={dataTestId}
         data-test-ref={dataTestRef}
         download={isDownload}
         href={url}

--- a/src/components/Hyperlink/Hyperlink.types.ts
+++ b/src/components/Hyperlink/Hyperlink.types.ts
@@ -15,6 +15,7 @@ type LinkStyle =
 type HyperlinkProps = {
   children: ReactNode;
   className?: string;
+  dataTestId?: string;
   dataTestRef?: string;
   hasTargetInNewWindow?: boolean;
   id?: string;


### PR DESCRIPTION
Adds the ability pass both a data-test-ref and a data-test-id to the Hyperlink component. 

This improves automation testing as we can specify items in lists more accurately. 