### PR TITLE
feat: export common Prop types for consumers

### DIFF
--- a/src/components/DateSelector/index.ts
+++ b/src/components/DateSelector/index.ts
@@ -1,3 +1,5 @@
 import { DateSelector } from './DateSelector';
+import type { DateSelectorProps } from './DateSelector.types';
 
 export { DateSelector };
+export type { DateSelectorProps };

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,3 +1,5 @@
 import { Select } from './Select';
+import type { SelectProps } from './Select.types';
 
 export { Select };
+export type { SelectProps };


### PR DESCRIPTION
This is to avoid having to re-declare those types in consuming code bases.