### PR TITLE
[Feature/CON-845 Add back button]

### DIFF
--- a/src/components/GlobalNavigation/GlobalNavigation.hooks.ts
+++ b/src/components/GlobalNavigation/GlobalNavigation.hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, MutableRefObject } from 'react';
 import { isViewport } from '~/utils/viewport';
 import { useWindowHasResized } from '~/customHooks';
-import type { ActiveViewTypes, StickyNavType } from './GlobalNavigation.types';
+import type { ActiveViewTypes, StickyNavType, UseOpenMenuFromSearch } from './GlobalNavigation.types';
 import { stickyScrollHandler } from './GlobalNavigation.utils';
 import throttle from 'lodash/throttle';
 
@@ -58,4 +58,19 @@ const useStickyNav = (
   return stickyNavRef;
 };
 
-export { useActiveView, useStickyNav };
+const useOpenMenuFromSearch: UseOpenMenuFromSearch = (
+  isOpenSearchBackToMenu,
+  setActiveCollectionId,
+) => {
+  useEffect(
+    () => {
+      if (isOpenSearchBackToMenu) {
+        setActiveCollectionId('top');
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Every time isOpenSearchBackToMenu change, will result in dispatching setActiveCollectionId.
+    [isOpenSearchBackToMenu],
+  );
+};
+
+export { useActiveView, useStickyNav, useOpenMenuFromSearch };

--- a/src/components/GlobalNavigation/GlobalNavigation.types.ts
+++ b/src/components/GlobalNavigation/GlobalNavigation.types.ts
@@ -157,6 +157,7 @@ type GlobalNavigationContextType = {
   className?: string;
   collections: Collection[];
   isVisuallyObstructed?: boolean;
+  isOpenSearchBackToMenu?: boolean;
   /** User created on Navigation close event callback */
   onClose?: () => void;
   /** User created on Navigation open event callback */
@@ -190,6 +191,11 @@ type GetCollectionLists = (
   topLevelCollections: Link[];
 };
 
+type UseOpenMenuFromSearch = (
+  isOpenSearchBackToMenu: boolean,
+  setActiveCollectionId: (menu: string) => void,
+) => void;
+
 export type {
   Article,
   Actions,
@@ -214,4 +220,5 @@ export type {
   UseGlobalNavigationStateContext,
   UseGlobalNavigationStateStore,
   UseGlobalNavigationStore,
+  UseOpenMenuFromSearch,
 };

--- a/src/components/GlobalNavigation/components/MobileView/MobileView.tsx
+++ b/src/components/GlobalNavigation/components/MobileView/MobileView.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import cx from 'classnames';
 import { ThemeContextProvider, useThemeContext } from '~/contexts';
-import { useStickyNav } from '../../GlobalNavigation.hooks';
+import {
+  useStickyNav,
+  useOpenMenuFromSearch,
+} from '../../GlobalNavigation.hooks';
 import {
   useEscapeKeyListener,
   useOnScreen,
@@ -32,6 +35,7 @@ const MobileView: MobileViewType = ({ className }) => {
     actions,
     collections,
     isVisuallyObstructed,
+    isOpenSearchBackToMenu,
     onClose,
     read,
     theme,
@@ -90,6 +94,8 @@ const MobileView: MobileViewType = ({ className }) => {
     actions.stores,
     actions.support,
   ];
+
+  useOpenMenuFromSearch(isOpenSearchBackToMenu, setActiveCollectionId);
 
   return (
     <ThemeContextProvider theme={currentTheme}>

--- a/src/customHooks/index.ts
+++ b/src/customHooks/index.ts
@@ -8,3 +8,4 @@ export { useOverflowHidden } from './useOverflowHidden';
 export { useScript } from './useScript';
 export { useTrapFocus } from './useTrapFocus';
 export { useWindowHasResized } from './useWindowHasResized';
+


### PR DESCRIPTION
-- Add 'isOpenSearchBackToMenu' in GlobalNavigation
-- Web-Ui will pass 'isOpenSearchBackToMenu' to 'MobileView.tsx' after clicking back button
-- 'isOpenSearchBackToMenu' is a boolean to control open Menu or not when travelling back from Search and Stores