### PR TITLE
fix(con-961): fix search icon color in light theme

### DIFF
--- a/src/components/GlobalNavigation/components/TabletView/components/PrimaryMenu/PrimaryMenu.module.css
+++ b/src/components/GlobalNavigation/components/TabletView/components/PrimaryMenu/PrimaryMenu.module.css
@@ -4,6 +4,18 @@
   transform: translateY(2px);
 }
 
+.iconDark {
+  path {
+    fill: var(--color-dark-label);
+  }
+}
+
+.iconLight {
+  path {
+    fill: var(--color-light-label);
+  }
+}
+
 .icon {
   margin-left: 4px;
 }

--- a/src/components/GlobalNavigation/components/TabletView/components/PrimaryMenu/PrimaryMenu.tsx
+++ b/src/components/GlobalNavigation/components/TabletView/components/PrimaryMenu/PrimaryMenu.tsx
@@ -51,6 +51,11 @@ const PrimaryMenu: PrimaryMenuType = ({ onClose }) => {
     [compositionStyles.menuClosed]: !isOpen,
   });
 
+  const searchIconSet = cx(styles.searchIcon, {
+    [styles.iconDark]: currentTheme === 'dark',
+    [styles.iconLight]: currentTheme === 'light',
+  });
+
   const handleOnCollectionClick = (id: string, callback?: () => void) => {
     setActiveCollectionId(id);
 
@@ -235,7 +240,7 @@ const PrimaryMenu: PrimaryMenuType = ({ onClose }) => {
           >
             <>
               <Icon
-                className={styles.searchIcon}
+                className={searchIconSet}
                 height={18}
                 name="search"
                 tabIndex={-1}


### PR DESCRIPTION
Ticket link:
https://aesoponline.atlassian.net/browse/CON-961

Issue:
Navigation renders search icon near-invisible on tablet in light theme.