### PR TITLE
fix(con-957): fix category heading not bold on some asian site

### DIFF
--- a/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.module.css
+++ b/src/components/GlobalNavigation/components/DesktopView/components/CollectionList/CollectionList.module.css
@@ -15,7 +15,7 @@
   margin-bottom: 12px;
   font-family: var(--font-family-sans-serif-medium);
   font-size: rem(14px);
-  font-weight: normal;
+  font-weight: var(--font-weight-medium);;
   line-height: 1.5;
 
   /* responsive font */

--- a/src/styles/variables/font.css
+++ b/src/styles/variables/font.css
@@ -2,6 +2,7 @@
   --font-base-size: 16px;
   --font-weight-light: 300;
   --font-weight-normal: 400;
+  --font-weight-medium: 500;
   --font-weight-semi-bold: 600;
   --font-weight-bold: 700;
   --font-family-sans-serif-regular: 'Suisse Regular', sans-serif;


### PR DESCRIPTION
Short term solution:

Change font-weight from 400 to 500 for all region.