### PR TITLE
fix(CON-943): fix video height in media block

### DIFF
--- a/src/components/DoubleMedia/components/MediaBlock/MediaBlock.tsx
+++ b/src/components/DoubleMedia/components/MediaBlock/MediaBlock.tsx
@@ -31,6 +31,7 @@ const MediaBlock: MediaBlockType = ({
         hasLoop={true}
         hasPlayInFullScreen={false}
         isFullWidth={true}
+        isInMediaBlock={true}
         isScrollBasedVideo={isScrollBasedVideo}
         poster={poster}
         sizes={sizes}

--- a/src/components/Video/Video.module.css
+++ b/src/components/Video/Video.module.css
@@ -111,3 +111,7 @@
     object-fit: cover;
   }
 }
+
+.mediaBlock.mediaBlock {
+  padding-top: 0;
+}

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -36,6 +36,7 @@ const Video = forwardRef<HTMLDivElement, VideoProps>(function VideoRef(
     isHeroFullWidth = false,
     isHeroFullWidthMobile = false,
     isScrollBasedVideo = false,
+    isInMediaBlock = false,
     sizes,
     poster,
   },
@@ -110,6 +111,7 @@ const Video = forwardRef<HTMLDivElement, VideoProps>(function VideoRef(
     [styles.heroFullWidthMobile]: isHeroFullWidthMobile,
     [styles.fullWidth]: isFullWidth,
     [styles.chrome]: isChrome,
+    [styles.mediaBlock]: isInMediaBlock,
   });
 
   return (

--- a/src/components/Video/Video.types.ts
+++ b/src/components/Video/Video.types.ts
@@ -31,9 +31,10 @@ type VideoProps = Pick<ControlsProps, 'copy'> & {
   hasSpanContent?: boolean;
   id?: string;
   isBackground?: boolean;
+  isInMediaBlock?: boolean;
   /**
     `isFullWidth` is set true by default and this will allow videos to display at the correct aspect ratio.
-    In the event that a different, more fluid ratio is required, set this prop to false, this will collapse the hight of the Video,
+    In the event that a different, more fluid ratio is required, set this prop to false, this will collapse the height of the Video,
     but it will react to the height of the surrounding element.
   */
   isFullWidth?: boolean;


### PR DESCRIPTION
Ticket link:
https://aesoponline.atlassian.net/browse/CON-943

Solution:
Remove padding-top of video in media block.

Before:
![Screen Shot 2021-11-09 at 9 14 02 am](https://user-images.githubusercontent.com/29698458/140827387-abd12dba-f5ab-4dac-b3d2-77ae5a704624.png)


 After:
![Screen Shot 2021-11-09 at 9 20 29 am](https://user-images.githubusercontent.com/29698458/140827405-2c7de47a-45bd-4deb-a205-b515a64637bf.png)




